### PR TITLE
Add simple CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,12 @@
+name: Deploy
+
+on:
+  push:
+    branches: main
+
+jobs:
+  test_and_lint:
+    uses: Ohtuprojekti-Fintraffic/lentovaraukset/.github/workflows/development.yml@main
+#  docker:
+#  build:
+#  release:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,35 @@
+name: Development
+
+on:
+  pull_request:
+    branches: main
+    types: [opened, synchronize, reopened]
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: install
+        run: npm install
+      - name: build
+        run: npm run build
+      - name: test
+        run: npm run test
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: install
+        run: npm install
+      - name: build
+        run: npm run build
+      - name: lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "start": "npm run start:backend & npm run start:frontend",
     "build": "npm -ws --if-present run build",
+    "test": "npm -ws --if-present run test",
     "start:backend": "npm -w @lentovaraukset/backend run start",
     "start:frontend": "npm -w @lentovaraukset/frontend run start"
   },
   "workspaces": [
-      "frontend",
-      "backend",
-      "shared"
+    "frontend",
+    "backend",
+    "shared"
   ]
 }


### PR DESCRIPTION
Simple CI/CD pipeline, where tests and lint are run on pull requests. Deploy workflow is run when pushed to main (currently there is no content for this workflow).

Related to #5 