### PR TITLE
Fix webpack bug for dev server

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require("webpack")
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-const BASE_PATH = process.env.BASE_PATH || '/';
+const BASE_PATH = process.env.BASE_PATH || '';
 
 const config = (env, argv) => {
   const HtmlWebpackPlugin = require('html-webpack-plugin');


### PR DESCRIPTION
Related to Issue #

## What changes has been added?

Bug with default BASE_PATH in webpack config leading to faulty URIs fixed. 
Example of bug: request for //main.js instead of /main.js

### Backend

No effect

### Frontend

DevServer loads main.js

## Expected Behaviour

Frontend loads.
