### PR TITLE
23 add editing timeslots

### DIFF
--- a/backend/__tests__/api/timeslotApi.test.ts
+++ b/backend/__tests__/api/timeslotApi.test.ts
@@ -1,0 +1,36 @@
+import request from 'supertest';
+import app from '@lentovaraukset/backend/src/index';
+import { Timeslot } from '@lentovaraukset/backend/src/models';
+import { connectToDatabase, sequelize } from '../../src/util/db';
+
+const api = request(app);
+
+beforeAll(async () => {
+  await connectToDatabase();
+});
+
+beforeEach(async () => {
+  // wipe db before each test
+  await sequelize.truncate({ cascade: true });
+});
+
+afterAll(async () => {
+  // otherwise Jest needs --forceExit
+  await sequelize.close();
+});
+describe('Calls to api', () => {
+
+  test('can edit a timeslot', async () => {
+    const createdSlot: Timeslot = await Timeslot.create({ startTime: '2023-01-01T12:00:00.000Z', maxAmount: 20 });
+
+    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}` )
+      .set('Content-type', 'application/json')
+      .send({ startTime:  '2023-01-02T12:00:00.000Z', maxAmount: 30 });
+    
+    const updatedSlot: Timeslot | null = await Timeslot.findOne({ where: { id: createdSlot.dataValues.id } });
+
+    expect(updatedSlot).toBeDefined();
+    expect(updatedSlot?.dataValues.startTime).toEqual(new Date('2023-01-02T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.maxAmount).toEqual(30);
+  });
+});

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '@lentovaraukset/backend/src/index';
 import { Timeslot } from '@lentovaraukset/backend/src/models';
-import { connectToDatabase, sequelize } from '../../src/util/db';
+import { connectToDatabase, sequelize } from '../src/util/db';
 
 const api = request(app);
 
@@ -19,15 +19,16 @@ afterAll(async () => {
   await sequelize.close();
 });
 describe('Calls to api', () => {
-
   test('can edit a timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ startTime: '2023-01-01T12:00:00.000Z', maxAmount: 20 });
 
-    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}` )
+    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
-      .send({ startTime:  '2023-01-02T12:00:00.000Z', maxAmount: 30 });
-    
-    const updatedSlot: Timeslot | null = await Timeslot.findOne({ where: { id: createdSlot.dataValues.id } });
+      .send({ startTime: '2023-01-02T12:00:00.000Z', maxAmount: 30 });
+
+    const updatedSlot: Timeslot | null = await Timeslot.findOne(
+      { where: { id: createdSlot.dataValues.id } },
+    );
 
     expect(updatedSlot).toBeDefined();
     expect(updatedSlot?.dataValues.startTime).toEqual(new Date('2023-01-02T12:00:00.000Z'));

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -19,4 +19,11 @@ router.delete('/:id', async (req: express.Request, res: express.Response) => {
   }
 });
 
+router.patch('/:id', async (req: express.Request, res: express.Response) => {
+  const id = Number(req.params.id);
+  const newTimeslot = req.body;
+  await timeslotService.updateById(id, newTimeslot);
+  res.status(200).json(newTimeslot);
+}) 
+
 export default router;

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -24,6 +24,6 @@ router.patch('/:id', async (req: express.Request, res: express.Response) => {
   const newTimeslot = req.body;
   await timeslotService.updateById(id, newTimeslot);
   res.status(200).json(newTimeslot);
-}) 
+});
 
 export default router;

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -11,9 +11,9 @@ const deleteById = async (id: number): Promise<boolean> => {
 
 const updateById = async (id: number, timeslot: { starttime: Date, maxDuration: number }) => {
   await Timeslot.update(timeslot, { where: { id } });
-}
+};
 
 export default {
   deleteById,
-  updateById
+  updateById,
 };

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -9,6 +9,11 @@ const deleteById = async (id: number): Promise<boolean> => {
   return false;
 };
 
+const updateById = async (id: number, timeslot: { starttime: Date, maxDuration: number }) => {
+  await Timeslot.update(timeslot, { where: { id } });
+}
+
 export default {
   deleteById,
+  updateById
 };


### PR DESCRIPTION
Related to Issue #23

## What changes has been added?

Route and service to update a timeslot.

### Backend

Calling /api/timeslots/:id with a patch request updates the slot information.

### Frontend

## Expected Behaviour

