### PR TITLE
fix time slot modification permanence

### DIFF
--- a/frontend/src/queries/reservations.ts
+++ b/frontend/src/queries/reservations.ts
@@ -1,12 +1,4 @@
-let placehoderReservations: any[] = [
-  {
-    id: '1',
-    title: 'test',
-    start: '2023-01-31T10:00:00',
-    end: '2023-01-31T10:45:00',
-    editable: true,
-  },
-];
+let placehoderReservations: any[] = [];
 
 const getReservations = async (): Promise<any[]> => (placehoderReservations);
 
@@ -19,7 +11,7 @@ const addReservation = async (newReservation: any): Promise<void> => {
 const modifyReservation = async (reservation: any): Promise<void> => {
   placehoderReservations[
     placehoderReservations.findIndex(
-      ((element) => parseInt(element.id, 10) === parseInt(reservation.id, 10)),
+      (element) => parseInt(element.id, 10) === parseInt(reservation.id, 10),
     )
   ] = {
     id: reservation.id,

--- a/frontend/src/queries/timeSlots.ts
+++ b/frontend/src/queries/timeSlots.ts
@@ -1,23 +1,5 @@
-let placehoderTimeSlots = [
-  {
-    id: '1',
-    start: '2023-01-31T10:00:00',
-    end: '2023-01-31T16:00:00',
-    editable: true,
-  },
-  {
-    id: '2',
-    start: '2023-02-01T10:00:00',
-    end: '2023-02-01T16:00:00',
-    editable: true,
-  },
-  {
-    id: '3',
-    start: '2023-02-02T10:00:00',
-    end: '2023-02-02T14:00:00',
-    editable: true,
-  },
-];
+let placehoderTimeSlots: any[] = [];
+
 const getTimeSlots = async (): Promise<any[]> => (placehoderTimeSlots);
 
 const addTimeSlot = async (newTimeSlot: any): Promise<void> => {
@@ -28,7 +10,9 @@ const addTimeSlot = async (newTimeSlot: any): Promise<void> => {
 
 const modifyTimeSlot = async (timeSlot: any): Promise<void> => {
   placehoderTimeSlots[
-    placehoderTimeSlots.findIndex(((element) => element.id === timeSlot.id))
+    placehoderTimeSlots.findIndex(
+      (element) => parseInt(element.id, 10) === parseInt(timeSlot.id, 10),
+    )
   ] = {
     id: timeSlot.id,
     start: timeSlot.start,


### PR DESCRIPTION
Related to Issue #
#57 Korjaus varausikkunoiden aikojen muutoksiin

## What changes has been added?

### Backend

- None

### Frontend

- Fixed modified timeslot times returning to their old value when adding a new timeslot
- Removed placeholder data from reservations and timeslots

## Expected Behaviour

- When an existing timeslots time is changed and a new one is added afterwards, the previous timeslot should keep the new time even after changing tabs