### PR TITLE
72 enforce timeslot granularity

### DIFF
--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import createTimeSlotValidator from '@lentovaraukset/shared/src/validation/validation';
 import timeslotService from '../services/timeslotService';
 
 const router = express.Router();
@@ -32,7 +33,9 @@ router.delete('/:id', async (req: express.Request, res: express.Response) => {
 
 router.post('/', async (req: express.Request, res: express.Response) => {
   try {
-    const newTimeSlot = req.body;
+    // TODO: get slotGranularityMinutes from airfield
+    const newTimeSlot = createTimeSlotValidator(20).parse(req.body);
+
     const timeslot = await timeslotService.createTimeslot(newTimeSlot);
     res.json(timeslot);
   } catch (error) {
@@ -41,10 +44,16 @@ router.post('/', async (req: express.Request, res: express.Response) => {
 });
 
 router.patch('/:id', async (req: express.Request, res: express.Response) => {
-  const id = Number(req.params.id);
-  const modifiedTimeslot = req.body;
-  await timeslotService.updateById(id, modifiedTimeslot);
-  res.status(200).json(modifiedTimeslot);
+  try {
+    // TODO: get slotGranularityMinutes from airfield
+    const modifiedTimeslot = createTimeSlotValidator(20).parse(req.body);
+
+    const id = Number(req.params.id);
+    await timeslotService.updateById(id, modifiedTimeslot);
+    res.status(200).json(modifiedTimeslot);
+  } catch (error) {
+    res.status(400).json(error);
+  }
 });
 
 export default router;

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -12,6 +12,8 @@ import {
 } from '../queries/timeSlots';
 
 function TimeSlotCalendar() {
+  const granularity = { minutes: 20 }; // TODO: Get from airfield api
+
   const calendarRef: React.RefObject<FullCalendar> = React.createRef();
 
   const [timeRange, setTimeRange] = useState({ start: new Date(), end: new Date() });
@@ -115,7 +117,8 @@ function TimeSlotCalendar() {
               nowIndicator
               scrollTime="08:00:00"
               dayHeaderFormat={{ weekday: 'long' }}
-              slotDuration="00:10:00"
+              slotDuration={granularity}
+              snapDuration={granularity}
               slotLabelInterval={{ minutes: 30 }}
               slotLabelFormat={{
                 hour: 'numeric', minute: '2-digit', hour12: false, meridiem: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14673,10 +14673,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "shared": {
       "name": "@lentovaraukset/shared",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "zod": "^3.20.6"
+      },
       "devDependencies": {}
     }
   },
@@ -16283,7 +16294,10 @@
       }
     },
     "@lentovaraukset/shared": {
-      "version": "file:shared"
+      "version": "file:shared",
+      "requires": {
+        "zod": "*"
+      }
     },
     "@mikro-orm/core": {
       "version": "4.5.10",
@@ -24233,6 +24247,11 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
     }
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,5 +7,7 @@
   "author": "",
   "main": "./dist/index.js",
   "scripts": {},
-  "devDependencies": {}
+  "dependencies": {
+    "zod": "^3.20.6"
+  }
 }

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+const minutesToMilliseconds = (minutes: number) => minutes * 1000 * 60;
+const isMultipleOfMinutes = (minutes: number) => (dateToCheck: Date) => (
+  dateToCheck.getTime() % minutesToMilliseconds(minutes) === 0
+);
+
+const createTimeSlotValidator = (slotGranularityMinutes: number) => {
+  const message = `Times must be multiples of ${slotGranularityMinutes} minutes`;
+  const TimeSlot = z.object({
+    start: z.coerce
+      .date()
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+    end: z.coerce
+      .date()
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+  });
+
+  return TimeSlot;
+};
+
+export default createTimeSlotValidator;


### PR DESCRIPTION
Related to Issue #
#72 

## What changes has been added?
Rules for timeslots' start and end times to be multiples of 20 minutes.
The duration of 20 minutes is hard coded for now but should be changed to come from the airfield config in when that is implemented.

### Backend
The api endpoints for adding and modifying timeslots now check if the timeslots' start and end times are multiples of 20 mins. If the validation fails a response with code 400 is sent. 

### Frontend
The timeslot calendar's slotDuration and snapDuration attributes have been set to 20 minutes.

### Shared
Added validation function for timeslots with zod.

## Expected Behaviour
It should not be possiple to add or modify timeslots so that the start and end times that are not multiples of 20 mins through neither the  frontend ui nor the api.