### PR TITLE
73 logotfontit eivät näy stagingissa

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     volumes: 
-      - ./data:/var/lib/postgresql/data
+      - data:/var/lib/postgresql/data
 
 volumes:
   data:

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,61 +1,55 @@
 const path = require('path');
-const webpack = require("webpack")
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const BASE_PATH = process.env.BASE_PATH || '';
 
-const config = (env, argv) => {
-  return {
-    entry: './src/index.tsx',
-    devtool: 'inline-source-map',
-    output: {
-      path: path.resolve(__dirname, 'dist'),
-      filename: 'main.js',
-      publicPath: `${BASE_PATH}`,
+const config = (env, argv) => ({
+  entry: './src/index.tsx',
+  devtool: 'inline-source-map',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'main.js',
+    publicPath: `${BASE_PATH}/`,
+  },
+  devServer: {
+    static: path.resolve(__dirname, 'dist'),
+    compress: true,
+    port: 3000,
+    open: true,
+    historyApiFallback: true,
+    proxy: {
+      '/api': 'http://localhost:8080',
     },
-    devServer: {
-      static: path.resolve(__dirname, 'dist'),
-      compress: true,
-      port: 3000,
-      open: true,
-      historyApiFallback: true,
-      proxy: {
-        '/api': 'http://localhost:8080',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
       },
-    },
-    module: {
-      rules: [
-        {
-          test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
-        },
-        {
-          test: /\.tsx?$/,
-          use: 'ts-loader',
-          exclude: /node_modules/,
-        },
-        {
-          test: /\.(png|jpe?g|gif)$/i,
-          use: [
-            {
-              loader: 'file-loader',
-            },
-          ],
-        },
-      ],
-    },
-    resolve: {
-      extensions: ['.tsx', '.ts', '.js'],
-    },
-    plugins: [
-      new HtmlWebpackPlugin({
-        template: './public/index.html',
-      }),
-      new webpack.DefinePlugin({
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.(png|jpe?g|gif)$/i,
+        use: 'file-loader',
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+    }),
+    new webpack.DefinePlugin({
       'process.env.BASE_PATH': JSON.stringify(BASE_PATH),
     }),
-    ],
-  };
-};
+  ],
+});
 
 module.exports = config;


### PR DESCRIPTION
Related to Issue #73 

## What changes has been added?

Fixed Webpack for staging.

### Backend

### Frontend

## Expected Behaviour

Fonts and image exports now work on the staging frontend.
