### PR TITLE
available timeslots for reservation calendar

### DIFF
--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -7,16 +7,19 @@ const getInTimeRange = async (rangeStartTime: Date, rangeEndTime: Date) => {
       [Op.or]: [{
         start: {
           [Op.between]: [rangeStartTime, rangeEndTime],
+          [Op.not]: [rangeEndTime],
         },
       }, {
         end: {
           [Op.between]: [rangeStartTime, rangeEndTime],
+          [Op.not]: [rangeStartTime],
         },
       }],
     },
   });
 
   return reservations.map((reservation) => ({
+    title: 'Varattu',
     id: reservation.dataValues.id,
     start: reservation.dataValues.start,
     end: reservation.dataValues.end,

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -46,11 +46,17 @@ function ReservationCalendar() {
     const calendar = calendarRef.current?.getApi();
     calendar?.removeAllEventSources();
     calendar?.addEventSource(reservations!);
-    calendar?.addEventSource({
-      events: timeslots?.map((timeslot) => ({ ...timeslot, groupId: 'timeslots' })),
-      display: 'inverse-background',
-      color: '#2C2C44',
-    });
+    calendar?.addEventSource(timeslots?.length
+      ? {
+        events: timeslots!.map((timeslot) => ({ ...timeslot, groupId: 'timeslots' })),
+        display: 'inverse-background',
+        color: '#2C2C44',
+      }
+      : {
+        events: [{ title: 'ei varattavissa', start: timeRange.start, end: timeRange.end }],
+        display: 'background',
+        color: '#720000',
+      });
   };
 
   useEffect(() => {
@@ -159,11 +165,18 @@ function ReservationCalendar() {
                 {
                   events: reservations,
                 },
-                {
-                  events: timeslots?.map((timeslot) => ({ ...timeslot, groupId: 'timeslots' })),
-                  display: 'inverse-background',
-                  color: '#2C2C44',
-                }]}
+                timeslots?.length
+                  ? {
+                    events: timeslots?.map((timeslot) => ({ ...timeslot, groupId: 'timeslots' })),
+                    display: 'inverse-background',
+                    color: '#2C2C44',
+                  }
+                  : {
+                    events: [{ title: 'ei varattavissa', start: timeRange.start, end: timeRange.end }],
+                    display: 'background',
+                    color: '#2C2C44',
+                  },
+              ]}
               datesSet={(dateInfo) => {
                 setTimeRange({ start: dateInfo.start, end: dateInfo.end });
               }}


### PR DESCRIPTION
Related to Issue #91 

## What changes has been added?
Available timeslots can be viewed in reservation calendar

### Backend
Placeholder title for reservations and excluded borderline cases 

### Frontend
New event source for timeslots in ReservationCalendar. check out [Background events](https://fullcalendar.io/docs/background-events) 

## Expected Behaviour
Available timeslots are shown as blank white, whereas unavailable timeslots are light grey.
![Screenshot from 2023-02-13 14-10-49](https://user-images.githubusercontent.com/65664408/218454356-b5816519-6ed2-4474-8917-6733b04b3435.png)

