### PR TITLE
108 add api tests to timeslot

### DIFF
--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -5,6 +5,12 @@ import { connectToDatabase, sequelize } from '../src/util/db';
 
 const api = request(app);
 
+const timeslot_data = [
+  {start: new Date('2023-02-02T08:00:00.000Z'), end: new Date('2023-02-02T10:00:00.000Z')},
+  {start: new Date('2023-02-02T14:00:00.000Z'), end: new Date('2023-02-02T16:00:00.000Z')},
+  {start: new Date('2023-02-02T16:00:00.000Z'), end: new Date('2023-02-02T18:00:00.000Z')},
+];
+
 beforeAll(async () => {
   await connectToDatabase();
 });
@@ -12,6 +18,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   // wipe db before each test
   await sequelize.truncate({ cascade: true });
+  await Timeslot.bulkCreate(timeslot_data);
 });
 
 afterAll(async () => {
@@ -19,6 +26,23 @@ afterAll(async () => {
   await sequelize.close();
 });
 describe('Calls to api', () => {
+
+  test('can create a timeslot', async () => {
+    await api.post('/api/timeslots/')
+      .set('Content-type', 'application/json')
+      .send({ start: '2023-03-03T12:00:00.000Z', end: '2023-03-03T14:00:00.000Z' });
+
+    const createdTimeslot: Timeslot | null = await Timeslot.findOne(
+      { where: { start: new Date('2023-03-03T12:00:00.000Z') } },
+    );
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslot_data.length + 1)
+    expect(createdTimeslot).toBeDefined();
+    expect(createdTimeslot?.dataValues.start).toEqual(new Date('2023-03-03T12:00:00.000Z'));
+    expect(createdTimeslot?.dataValues.end).toEqual(new Date('2023-03-03T14:00:00.000Z'));
+  });
+
   test('can edit a timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: '2023-01-01T12:00:00.000Z', end: '2023-01-01T13:00:00.000Z' });
 
@@ -33,5 +57,17 @@ describe('Calls to api', () => {
     expect(updatedSlot).toBeDefined();
     expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-02T12:00:00.000Z'));
     expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-02T14:00:00.000Z'));
+  });
+
+  test('can delete a timeslot', async () => {
+
+    const createdSlot: Timeslot | null = await Timeslot.findOne({});
+    await api.delete(`/api/timeslots/${createdSlot?.dataValues.id}`)
+
+    const deletedSlot: Timeslot | null = await Timeslot.findByPk(createdSlot?.dataValues.id);
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslot_data.length - 1);
+    expect(deletedSlot).toEqual(null)
   });
 });

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -6,12 +6,16 @@ import { connectToDatabase, sequelize } from '../src/util/db';
 const api = request(app);
 
 const timeslotData = [
-  {start: new Date('2023-02-02T08:00:00.000Z'), end: new Date('2023-02-02T10:00:00.000Z')},
-  {start: new Date('2023-02-02T14:00:00.000Z'), end: new Date('2023-02-02T16:00:00.000Z')},
-  {start: new Date('2023-02-02T16:00:00.000Z'), end: new Date('2023-02-02T18:00:00.000Z')},
+  { start: new Date('2023-02-02T08:00:00.000Z'), end: new Date('2023-02-02T10:00:00.000Z') },
+  { start: new Date('2023-02-02T14:00:00.000Z'), end: new Date('2023-02-02T16:00:00.000Z') },
+  { start: new Date('2023-02-02T16:00:00.000Z'), end: new Date('2023-02-02T18:00:00.000Z') },
 ];
-const timeslotDataBegin = timeslotData.reduce((prev, cur) => (cur.start < prev.start ? cur : prev)).start;
-const timeslotDataEnd = timeslotData.reduce((prev, cur) => (cur.end > prev.end ? cur : prev)).end;
+const timeslotDataBegin = timeslotData.reduce(
+  (prev, cur) => (cur.start < prev.start ? cur : prev),
+).start;
+const timeslotDataEnd = timeslotData.reduce(
+  (prev, cur) => (cur.end > prev.end ? cur : prev),
+).end;
 
 beforeAll(async () => {
   await connectToDatabase();
@@ -28,7 +32,6 @@ afterAll(async () => {
   await sequelize.close();
 });
 describe('Calls to api', () => {
-
   test('can create a timeslot', async () => {
     await api.post('/api/timeslots/')
       .set('Content-type', 'application/json')
@@ -43,6 +46,44 @@ describe('Calls to api', () => {
     expect(createdTimeslot).not.toEqual(null);
     expect(createdTimeslot?.dataValues.start).toEqual(new Date('2023-03-03T12:00:00.000Z'));
     expect(createdTimeslot?.dataValues.end).toEqual(new Date('2023-03-03T14:00:00.000Z'));
+  });
+
+  test('dont create a timeslot if all fields not provided', async () => {
+    await api.post('/api/timeslots/')
+      .set('Content-type', 'application/json')
+      .send({ start: '2023-03-03T12:00:00.000Z' });
+
+    const createdTimeslot: Timeslot | null = await Timeslot.findOne(
+      { where: { start: new Date('2023-03-03T12:00:00.000Z') } },
+    );
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslotData.length);
+    expect(createdTimeslot).toEqual(null);
+  });
+
+  test('dont create a timeslot if granularity is wrong', async () => {
+    await api.post('/api/timeslots/')
+      .set('Content-type', 'application/json')
+      .send({ start: '2023-03-03T12:00:00.000Z', end: '2023-03-03T12:15:00.000Z' });
+
+    const createdTimeslot: Timeslot | null = await Timeslot.findOne(
+      { where: { start: new Date('2023-03-03T12:00:00.000Z') } },
+    );
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslotData.length);
+    expect(createdTimeslot).toEqual(null);
+  });
+
+  test('dont create a timeslot if provided times are empty', async () => {
+    await api.post('/api/timeslots/')
+      .set('Content-type', 'application/json')
+      .send({ start: '', end: '' });
+
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslotData.length);
   });
 
   test('can edit a timeslot', async () => {
@@ -61,6 +102,38 @@ describe('Calls to api', () => {
     expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-02T14:00:00.000Z'));
   });
 
+  test('dont edit a timeslot if all fields not provided', async () => {
+    const createdSlot: Timeslot = await Timeslot.create({ start: '2023-01-01T12:00:00.000Z', end: '2023-01-01T13:00:00.000Z' });
+
+    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
+      .set('Content-type', 'application/json')
+      .send({ start: '2023-01-02T12:00:00.000Z' });
+
+    const updatedSlot: Timeslot | null = await Timeslot.findOne(
+      { where: { id: createdSlot.dataValues.id } },
+    );
+
+    expect(updatedSlot).not.toEqual(null);
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-01T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-01T13:00:00.000Z'));
+  });
+
+  test('dont edit a timeslot if granularity is wrong', async () => {
+    const createdSlot: Timeslot = await Timeslot.create({ start: '2023-01-01T12:00:00.000Z', end: '2023-01-01T13:00:00.000Z' });
+
+    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
+      .set('Content-type', 'application/json')
+      .send({ start: '2023-01-02T12:00:00.000Z', end: '2023-01-02T13:15:00.000Z' });
+
+    const updatedSlot: Timeslot | null = await Timeslot.findOne(
+      { where: { id: createdSlot.dataValues.id } },
+    );
+
+    expect(updatedSlot).not.toEqual(null);
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-01T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-01T13:00:00.000Z'));
+  });
+
   test('can delete a timeslot', async () => {
     const createdSlot: Timeslot | null = await Timeslot.findOne({});
     await api.delete(`/api/timeslots/${createdSlot?.dataValues.id}`);
@@ -72,17 +145,33 @@ describe('Calls to api', () => {
     expect(deletedSlot).toEqual(null);
   });
 
+  test('dont delete a timeslot if it doesnt exist', async () => {
+    await api.delete('/api/timeslots/-1');
+
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslotData.length);
+  });
+
+  test('dont delete a timeslot if id is not a number', async () => {
+    await api.delete('/api/timeslots/test');
+
+    const numberOfTimeslots: Number = await Timeslot.count();
+
+    expect(numberOfTimeslots).toEqual(timeslotData.length);
+  });
+
   test('can get timeslots in a range', async () => {
     const from = new Date(timeslotDataBegin);
     const until = new Date(timeslotDataEnd);
     const response = await api.get(`/api/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
     const timeslots = response.body;
-    const start_times = timeslots.map((o: { start: String; }) => o.start);
+    const startTimes = timeslots.map((o: { start: String; }) => o.start);
 
     expect(timeslots.length).toEqual(timeslotData.length);
-    expect(start_times.includes(timeslotData[0].start));
-    expect(start_times.includes(timeslotData[1].start));
-    expect(start_times.includes(timeslotData[2].start));
+    expect(startTimes.includes(timeslotData[0].start));
+    expect(startTimes.includes(timeslotData[1].start));
+    expect(startTimes.includes(timeslotData[2].start));
   });
 
   test('return empty list if no timeslots in range', async () => {
@@ -91,8 +180,7 @@ describe('Calls to api', () => {
     from.setDate(until.getDate() + 1);
     until.setDate(until.getDate() + 2);
     const response = await api.get(`/api/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
-    const timeslots = response.body;
-    
+
     expect(response.body).toEqual([]);
   });
 });


### PR DESCRIPTION
Related to Issue #108 

## What changes has been added?

### Backend

API tests to timeslots for typical use cases

### Frontend

## Expected Behaviour

No changes
