### PR TITLE
remove re-rendering when opening/closing but not removing the reserva…

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import listPlugin from '@fullcalendar/list';
 import interactionPlugin from '@fullcalendar/interaction';
 import {
-  DateSelectArg, EventChangeArg, EventClickArg, EventSourceInput, OverlapFunc,
+  DateSelectArg, EventChangeArg, EventClickArg, EventRemoveArg, EventSourceInput, OverlapFunc,
 } from '@fullcalendar/core';
 import { EventImpl } from '@fullcalendar/core/internal';
 
@@ -15,6 +15,7 @@ type CalendarProps = {
   addEventFn: (event: { start: Date; end: Date }) => Promise<void>;
   modifyEventFn: (event: { id: string; start: Date; end: Date }) => Promise<void>;
   clickEventFn: (event: EventImpl) => Promise<void>;
+  removeEventFn: (event: EventRemoveArg) => Promise<void>;
   granularity: { minutes: number };
   eventColors: {
     backgroundColor?: string;
@@ -30,6 +31,7 @@ function Calendar({
   addEventFn,
   modifyEventFn,
   clickEventFn,
+  removeEventFn,
   granularity,
   eventColors,
   selectConstraint,
@@ -87,6 +89,12 @@ function Calendar({
     calendarRef.current?.getApi().unselect();
   };
 
+  const handleEventRemove = async (removeInfo: EventRemoveArg) => {
+    await removeEventFn(removeInfo);
+    calendarRef.current?.getApi().refetchEvents();
+    calendarRef.current?.getApi().unselect();
+  };
+
   return (
     <FullCalendar
       ref={calendarRef}
@@ -120,9 +128,10 @@ function Calendar({
       eventTextColor={eventColors?.textColor || '#000000'}
       eventClick={handleEventClick}
       eventChange={handleEventChange}
+      eventRemove={handleEventRemove}
       select={handleEventCreate}
       selectConstraint={selectConstraint}
-      eventSources={useMemo(() => eventSources, [calendarRef])}
+      eventSources={eventSources}
       eventOverlap={areEventsColliding}
       selectOverlap={newEventColliding}
     />

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -14,11 +14,7 @@ type CalendarProps = {
   eventSources: EventSourceInput[];
   addEventFn: (event: { start: Date; end: Date }) => Promise<void>;
   modifyEventFn: (event: { id: string; start: Date; end: Date }) => Promise<void>;
-  clickEventFn: (event: {
-    id: string;
-    start?: Date;
-    end?: Date;
-    title?: string }) => Promise<void>;
+  clickEventFn: (event: EventImpl) => Promise<void>;
   granularity: { minutes: number };
   eventColors: {
     backgroundColor?: string;
@@ -63,18 +59,8 @@ function Calendar({
   // When a event box is clicked
   const handleEventClick = async (clickData: EventClickArg) => {
     if (clickData.event.display.includes('background')) return;
-
     const { event } = clickData;
-
-    await clickEventFn({
-      id: event.id,
-      start: event.start || undefined,
-      end: event.start || undefined,
-      title: event.title,
-    });
-
-    // Refresh calendar if changes were made
-    calendarRef.current?.getApi().refetchEvents();
+    await clickEventFn(event);
   };
 
   // When a event box is moved or resized
@@ -97,7 +83,6 @@ function Calendar({
       start: dropData.start,
       end: dropData.end,
     });
-
     calendarRef.current?.getApi().refetchEvents();
     calendarRef.current?.getApi().unselect();
   };
@@ -137,7 +122,7 @@ function Calendar({
       eventChange={handleEventChange}
       select={handleEventCreate}
       selectConstraint={selectConstraint}
-      eventSources={eventSources}
+      eventSources={useMemo(() => eventSources, [calendarRef])}
       eventOverlap={areEventsColliding}
       selectOverlap={newEventColliding}
     />

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -10,7 +10,6 @@ import {
 import { EventImpl } from '@fullcalendar/core/internal';
 
 type CalendarProps = {
-  calendarRef?: React.RefObject<FullCalendar>;
   eventSources: EventSourceInput[];
   addEventFn: (event: { start: Date; end: Date }) => Promise<void>;
   modifyEventFn: (event: { id: string; start: Date; end: Date }) => Promise<void>;
@@ -26,7 +25,6 @@ type CalendarProps = {
 };
 
 function Calendar({
-  calendarRef = React.createRef(),
   eventSources,
   addEventFn,
   modifyEventFn,
@@ -36,6 +34,8 @@ function Calendar({
   eventColors,
   selectConstraint,
 }: CalendarProps) {
+  const calendarRef: React.RefObject<FullCalendar> = React.createRef();
+
   const isOverlap = (eventA: EventImpl, eventB: EventImpl) => {
     if (eventA.start && eventA.end && eventB.start && eventB.end) {
       return !(eventA.end <= eventB.start || eventB.end <= eventA.start);

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -73,11 +73,11 @@ function ReservationCalendar() {
     const res = await deleteReservation(Number(event.id));
     if (res === `Reservation ${selectedReservation?.id} deleted`) {
       closeReservationModalFn();
+      setSelectedReservation(null);
     } else {
       removeInfo.revert();
       throw new Error('Removing reservation failed');
     }
-    setSelectedReservation(null);
   };
 
   return (

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -1,6 +1,5 @@
-import { EventSourceFunc } from '@fullcalendar/core';
+import { EventRemoveArg, EventSourceFunc } from '@fullcalendar/core';
 import React from 'react';
-
 import Calendar from '../components/Calendar';
 import {
   getTimeSlots, modifyTimeSlot, addTimeSlot, deleteTimeslot,
@@ -27,6 +26,10 @@ function TimeSlotCalendar() {
     }
   };
 
+  const removeTimeSlot = async (removeInfo: EventRemoveArg) => {
+    const { event } = removeInfo;
+    await deleteTimeslot(Number(event.id));
+  };
   return (
     <div className="flex flex-col space-y-2 h-full w-full">
       <h1 className="text-3xl">Vapaat varausikkunat</h1>
@@ -35,6 +38,7 @@ function TimeSlotCalendar() {
         addEventFn={addTimeSlot}
         modifyEventFn={modifyTimeSlot}
         clickEventFn={clickEventFn}
+        removeEventFn={removeTimeSlot}
         granularity={{ minutes: 20 }} // TODO: Get from airfield api
         eventColors={{ backgroundColor: '#bef264', eventColor: '#84cc16', textColor: '#000000' }}
         selectConstraint={undefined}


### PR DESCRIPTION
Related to Issue #144 

## What changes has been added?

### Backend
no changes 
### Frontend
Removed unnecessary re-rendering of Reservation calendar everytime modal was opened or closed. Added eventRemove callback functionality to make event removing atomic.

## Expected Behaviour
same as before, with less re-renders