### PR TITLE
Tarkasta liittyykö aikaikkunaan varauksia ennenkuin se poistetaan tai muokataan

### DIFF
--- a/backend/src/routes/reservations.ts
+++ b/backend/src/routes/reservations.ts
@@ -18,15 +18,12 @@ router.get('/', async (req: express.Request, res: express.Response) => {
 router.delete('/:id', async (req: express.Request, res: express.Response) => {
   const id = Number(req.params.id);
   try {
-    const deleted = await reservationService.deleteById(id);
-    if (deleted) {
-      res.send(`Reservation ${id} deleted`);
-    } else {
-      res.status(404).json(`Reservation ${id} not found`);
-    }
+    await reservationService.deleteById(id);
+    res.send(`Reservation ${id} deleted`);
   } catch (error: unknown) {
     if (error instanceof Error) {
-      res.status(500).json(error);
+      console.log(error);
+      res.status(400).json(error.message);
     }
   }
 });
@@ -36,9 +33,11 @@ router.post('/', async (req: express.Request, res: express.Response) => {
     const newReservation = createReservationValidator(10).parse(req.body);
     const reservation = await reservationService.createReservation(newReservation);
     res.json(reservation);
-  } catch (error) {
-    console.log(error);
-    res.status(400).json(error);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.log(error);
+      res.status(400).json(error.message);
+    }
   }
 });
 
@@ -48,9 +47,11 @@ router.patch('/:id', async (req: express.Request, res: express.Response) => {
     const validReservationUpdate = updateReservationValidator(10).parse(req.body);
     const modifiedReservation = await reservationService.updateById(id, validReservationUpdate);
     res.status(200).json(modifiedReservation);
-  } catch (error) {
-    console.log(error);
-    res.status(400).json(error);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.log(error);
+      res.status(400).json(error.message);
+    }
   }
 });
 

--- a/backend/src/routes/reservations.ts
+++ b/backend/src/routes/reservations.ts
@@ -22,7 +22,6 @@ router.delete('/:id', async (req: express.Request, res: express.Response) => {
     res.send(`Reservation ${id} deleted`);
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.log(error);
       res.status(400).json(error.message);
     }
   }
@@ -35,7 +34,6 @@ router.post('/', async (req: express.Request, res: express.Response) => {
     res.json(reservation);
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.log(error);
       res.status(400).json(error.message);
     }
   }
@@ -49,7 +47,6 @@ router.patch('/:id', async (req: express.Request, res: express.Response) => {
     res.status(200).json(modifiedReservation);
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.log(error);
       res.status(400).json(error.message);
     }
   }

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -21,7 +21,6 @@ router.delete('/:id', async (req: express.Request, res: express.Response) => {
     await timeslotService.deleteById(id);
     res.send(`Timeslot ${id} deleted`);
   } catch (error: unknown) {
-    console.log(error);
     if (error instanceof Error) {
       res.status(400).json(error.message);
     }
@@ -36,7 +35,6 @@ router.post('/', async (req: express.Request, res: express.Response) => {
     const timeslot = await timeslotService.createTimeslot(newTimeSlot);
     res.json(timeslot);
   } catch (error: unknown) {
-    console.log(error);
     if (error instanceof Error) {
       res.status(400).json(error.message);
     }
@@ -52,7 +50,6 @@ router.patch('/:id', async (req: express.Request, res: express.Response) => {
     await timeslotService.updateById(id, modifiedTimeslot);
     res.status(200).json(modifiedTimeslot);
   } catch (error: unknown) {
-    console.log(error);
     if (error instanceof Error) {
       res.status(400).json(error.message);
     }

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -18,15 +18,12 @@ router.get('/', async (req: express.Request, res: express.Response) => {
 router.delete('/:id', async (req: express.Request, res: express.Response) => {
   const id = Number(req.params.id);
   try {
-    const deleted = await timeslotService.deleteById(id);
-    if (deleted) {
-      res.send(`Timeslot ${id} deleted`);
-    } else {
-      res.status(404).json(`Timeslot ${id} not found`);
-    }
+    await timeslotService.deleteById(id);
+    res.send(`Timeslot ${id} deleted`);
   } catch (error: unknown) {
+    console.log(error);
     if (error instanceof Error) {
-      res.status(500).json(error);
+      res.status(400).json(error.message);
     }
   }
 });
@@ -38,9 +35,11 @@ router.post('/', async (req: express.Request, res: express.Response) => {
 
     const timeslot = await timeslotService.createTimeslot(newTimeSlot);
     res.json(timeslot);
-  } catch (error) {
+  } catch (error: unknown) {
     console.log(error);
-    res.status(400).json(error);
+    if (error instanceof Error) {
+      res.status(400).json(error.message);
+    }
   }
 });
 
@@ -52,9 +51,11 @@ router.patch('/:id', async (req: express.Request, res: express.Response) => {
     const id = Number(req.params.id);
     await timeslotService.updateById(id, modifiedTimeslot);
     res.status(200).json(modifiedTimeslot);
-  } catch (error) {
+  } catch (error: unknown) {
     console.log(error);
-    res.status(400).json(error);
+    if (error instanceof Error) {
+      res.status(400).json(error.message);
+    }
   }
 });
 

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -24,21 +24,7 @@ const getReservationFromRange = async (startTime: Date, endTime: Date) => {
 };
 
 const getInTimeRange = async (rangeStartTime: Date, rangeEndTime: Date) => {
-  const reservations = await Reservation.findAll({
-    where: {
-      [Op.or]: [{
-        start: {
-          [Op.between]: [rangeStartTime, rangeEndTime],
-          [Op.not]: [rangeEndTime],
-        },
-      }, {
-        end: {
-          [Op.between]: [rangeStartTime, rangeEndTime],
-          [Op.not]: [rangeStartTime],
-        },
-      }],
-    },
-  });
+  const reservations = await getReservationFromRange(rangeStartTime, rangeEndTime);
 
   return reservations.map(({ id, start, end }) => ({
     title: 'Varattu', id, start, end,

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -8,12 +8,16 @@ const numConcurrentReservations: number = 1;
 const getReservationFromRange = async (startTime: Date, endTime: Date) => {
   const reservations: Reservation[] = await Reservation.findAll({
     where: {
-      start: {
-        [Op.lt]: endTime,
-      },
-      end: {
-        [Op.gt]: startTime,
-      },
+      [Op.and]: [
+        {
+          start: {
+            [Op.gte]: startTime,
+          },
+          end: {
+            [Op.lte]: endTime,
+          },
+        },
+      ],
     },
   });
   return reservations;

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -83,13 +83,12 @@ const allowNewReservation = async (
   return reservations.length >= numConcurrentReservations;
 };
 
-const deleteById = async (id: number): Promise<boolean> => {
+const deleteById = async (id: number) => {
   const reservation = await Reservation.findByPk(id);
-  if (reservation) {
-    reservation.destroy();
-    return true;
+  if (!reservation) {
+    throw new Error('Reservation does not exist');
   }
-  return false;
+  reservation.destroy();
 };
 
 const createReservation = async (newReservation: {

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -6,12 +6,16 @@ import { Timeslot } from '../models';
 const getTimeslotFromRange = async (startTime: Date, endTime: Date) => {
   const timeslots: Timeslot[] = await Timeslot.findAll({
     where: {
-      start: {
-        [Op.lt]: endTime,
-      },
-      end: {
-        [Op.gt]: startTime,
-      },
+      [Op.and]: [
+        {
+          start: {
+            [Op.gte]: startTime,
+          },
+          end: {
+            [Op.lte]: endTime,
+          },
+        },
+      ],
     },
   });
   return timeslots;
@@ -42,6 +46,10 @@ const getInTimeRange = async (
 
 const deleteById = async (id: number): Promise<boolean> => {
   const timeslot = await Timeslot.findByPk(id);
+  const reservations = await timeslot?.getReservations();
+  if (reservations?.length !== 0) {
+    throw new Error('Timeslot has reservations');
+  }
   if (timeslot) {
     timeslot.destroy();
     return true;

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -44,17 +44,16 @@ const getInTimeRange = async (
   return timeslots.map(({ id, start, end }) => ({ id, start, end }));
 };
 
-const deleteById = async (id: number): Promise<boolean> => {
+const deleteById = async (id: number) => {
   const timeslot = await Timeslot.findByPk(id);
+  if (!timeslot) {
+    throw new Error('Timeslot does not exist');
+  }
   const reservations = await timeslot?.getReservations();
   if (reservations?.length !== 0) {
     throw new Error('Timeslot has reservations');
   }
-  if (timeslot) {
-    timeslot.destroy();
-    return true;
-  }
-  return false;
+  timeslot?.destroy();
 };
 
 const updateById = async (

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -9,10 +9,10 @@ const getTimeslotFromRange = async (startTime: Date, endTime: Date) => {
       [Op.and]: [
         {
           start: {
-            [Op.gte]: startTime,
+            [Op.lte]: startTime,
           },
           end: {
-            [Op.lte]: endTime,
+            [Op.gte]: endTime,
           },
         },
       ],
@@ -65,6 +65,9 @@ const updateById = async (
     .getReservationFromRange(timeslot.start, timeslot.end);
   const oldTimeslot: Timeslot | null = await Timeslot.findByPk(id);
   const oldReservations = await oldTimeslot?.getReservations();
+  if (oldReservations?.length !== newReservations?.length) {
+    throw new Error('Timeslot has reservations');
+  }
   await oldTimeslot?.removeReservations(oldReservations);
   await oldTimeslot?.addReservations(newReservations);
   await Timeslot.update(timeslot, { where: { id } });


### PR DESCRIPTION
Related to Issue #145 

## What changes has been added?
It is only possible to delete timeslot if it has no reservations and to modify so that reservation doesn't go outside of free time range.

### Backend
Restrictions added for deleting and modifyinfg timeslots. Also error sending modified so that the correct error message is sent as http response.

### Frontend
No changes.

## Expected Behaviour
If timeslot with reservation is tried to delete or to edit so that reservation goes outside, nothing happens.
