### PR TITLE
Käyttäjä ei voi luoda timeslotteja tai varauksia menneisyyteen

### DIFF
--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -145,4 +145,19 @@ describe('Calls to api', () => {
       .get(`/api/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
     expect(response.body).toEqual([]);
   });
+
+  test('Reservation cannot be add in past', async () => {
+    const start = new Date();
+    start.setDate(start.getDate() - 1);
+    start.setHours(start.getHours() - 2);
+    const end = new Date();
+    end.setDate(end.getDate() - 1);
+    const newReservation: any = await api.post('/api/reservations/')
+      .set('Content-type', 'application/json')
+      .send({
+        start, end, aircraftId: 'OH-QAA', phone: '11104040',
+      });
+
+    expect(newReservation).toEqual(null);
+  });
 });

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -6,9 +6,9 @@ import { connectToDatabase, sequelize } from '../src/util/db';
 const api = request(app);
 
 const timeslotData = [
-  { start: new Date('2023-02-02T08:00:00.000Z'), end: new Date('2023-02-02T10:00:00.000Z') },
-  { start: new Date('2023-02-02T14:00:00.000Z'), end: new Date('2023-02-02T16:00:00.000Z') },
-  { start: new Date('2023-02-02T16:00:00.000Z'), end: new Date('2023-02-02T18:00:00.000Z') },
+  { start: new Date('2023-02-14T08:00:00.000Z'), end: new Date('2023-02-14T10:00:00.000Z') },
+  { start: new Date('2023-02-14T14:00:00.000Z'), end: new Date('2023-02-14T16:00:00.000Z') },
+  { start: new Date('2023-02-14T16:00:00.000Z'), end: new Date('2023-02-14T18:00:00.000Z') },
 ];
 const timeslotDataBegin = timeslotData.reduce(
   (prev, cur) => (cur.start < prev.start ? cur : prev),
@@ -20,6 +20,12 @@ const timeslotDataEnd = timeslotData.reduce(
 
 beforeAll(async () => {
   await connectToDatabase();
+
+  // backend uses system time for some stuff
+  // so let's fake it as a specific date,
+  // while keeping timers running
+  jest.useFakeTimers({ advanceTimers: true });
+  jest.setSystemTime(new Date('2023-02-13T08:00:00.000Z'));
 });
 
 beforeEach(async () => {
@@ -29,6 +35,9 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
+  // return to the present
+  jest.useRealTimers();
+
   // otherwise Jest needs --forceExit
   await sequelize.close();
 });
@@ -36,26 +45,26 @@ describe('Calls to api', () => {
   test('can create a timeslot', async () => {
     await api.post('/api/timeslots/')
       .set('Content-type', 'application/json')
-      .send({ start: '2023-03-03T12:00:00.000Z', end: '2023-03-03T14:00:00.000Z' });
+      .send({ start: new Date('2023-02-18T12:00:00.000Z'), end: new Date('2023-02-18T14:00:00.000Z') });
 
     const createdTimeslot: Timeslot | null = await Timeslot.findOne(
-      { where: { start: new Date('2023-03-03T12:00:00.000Z') } },
+      { where: { start: new Date('2023-02-18T12:00:00.000Z') } },
     );
     const numberOfTimeslots: Number = await Timeslot.count();
 
     expect(numberOfTimeslots).toEqual(timeslotData.length + 1);
     expect(createdTimeslot).not.toEqual(null);
-    expect(createdTimeslot?.dataValues.start).toEqual(new Date('2023-03-03T12:00:00.000Z'));
-    expect(createdTimeslot?.dataValues.end).toEqual(new Date('2023-03-03T14:00:00.000Z'));
+    expect(createdTimeslot?.dataValues.start).toEqual(new Date('2023-02-18T12:00:00.000Z'));
+    expect(createdTimeslot?.dataValues.end).toEqual(new Date('2023-02-18T14:00:00.000Z'));
   });
 
   test('dont create a timeslot if all fields not provided', async () => {
     await api.post('/api/timeslots/')
       .set('Content-type', 'application/json')
-      .send({ start: '2023-03-03T12:00:00.000Z' });
+      .send({ start: '2023-02-18T12:00:00.000Z' });
 
     const createdTimeslot: Timeslot | null = await Timeslot.findOne(
-      { where: { start: new Date('2023-03-03T12:00:00.000Z') } },
+      { where: { start: new Date('2023-02-18T12:00:00.000Z') } },
     );
     const numberOfTimeslots: Number = await Timeslot.count();
 
@@ -66,10 +75,10 @@ describe('Calls to api', () => {
   test('dont create a timeslot if granularity is wrong', async () => {
     await api.post('/api/timeslots/')
       .set('Content-type', 'application/json')
-      .send({ start: new Date('2023-03-03T12:00:00.000Z'), end: new Date('2023-03-03T12:15:00.000Z') });
+      .send({ start: new Date('2023-02-18T12:00:00.000Z'), end: new Date('2023-02-18T12:15:00.000Z') });
 
     const createdTimeslot: Timeslot | null = await Timeslot.findOne(
-      { where: { start: new Date('2023-03-03T12:00:00.000Z') } },
+      { where: { start: new Date('2023-02-18T12:00:00.000Z') } },
     );
     const numberOfTimeslots: Number = await Timeslot.count();
 
@@ -88,26 +97,26 @@ describe('Calls to api', () => {
   });
 
   test('can edit a timeslot', async () => {
-    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-01-01T12:00:00.000Z'), end: new Date('2023-01-01T13:00:00.000Z') });
+    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z') });
 
     await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
-      .send({ start: '2023-01-02T12:00:00.000Z', end: '2023-01-02T14:00:00.000Z' });
+      .send({ start: '2023-02-17T12:00:00.000Z', end: '2023-02-17T14:00:00.000Z' });
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },
     );
 
     expect(updatedSlot).toBeDefined();
-    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-02T12:00:00.000Z'));
-    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-02T14:00:00.000Z'));
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-02-17T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-17T14:00:00.000Z'));
   });
 
   test('can edit a timeslot with reservation', async () => {
-    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-01-01T12:00:00.000Z'), end: new Date('2023-01-01T13:00:00.000Z') });
+    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z') });
     const newReservation: Reservation = await Reservation.create({
-      start: new Date('2023-01-01T12:00:00.000Z'),
-      end: new Date('2023-01-01T13:00:00.000Z'),
+      start: new Date('2023-02-16T12:00:00.000Z'),
+      end: new Date('2023-02-16T13:00:00.000Z'),
       aircraftId: 'ESA-111',
       phone: '0501102323',
     });
@@ -115,54 +124,54 @@ describe('Calls to api', () => {
 
     await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
-      .send({ start: '2023-01-01T12:00:00.000Z', end: '2023-01-01T14:00:00.000Z' });
+      .send({ start: '2023-02-16T12:00:00.000Z', end: '2023-02-16T14:00:00.000Z' });
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },
     );
 
     expect(updatedSlot).not.toEqual(null);
-    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-01T12:00:00.000Z'));
-    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-01T14:00:00.000Z'));
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-02-16T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-16T14:00:00.000Z'));
   });
 
   test('dont edit a timeslot if all fields not provided', async () => {
-    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-01-01T12:00:00.000Z'), end: new Date('2023-01-01T13:00:00.000Z') });
+    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z') });
 
     await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
-      .send({ start: '2023-01-02T12:00:00.000Z' });
+      .send({ start: '2023-02-17T12:00:00.000Z' });
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },
     );
 
     expect(updatedSlot).not.toEqual(null);
-    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-01T12:00:00.000Z'));
-    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-01T13:00:00.000Z'));
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-02-16T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-16T13:00:00.000Z'));
   });
 
   test('dont edit a timeslot if granularity is wrong', async () => {
-    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-01-01T12:00:00.000Z'), end: new Date('2023-01-01T13:00:00.000Z') });
+    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z') });
 
     await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
-      .send({ start: new Date('2023-01-02T12:00:00.000Z'), end: new Date('2023-01-02T13:15:00.000Z') });
+      .send({ start: new Date('2023-02-17T12:00:00.000Z'), end: new Date('2023-02-17T13:15:00.000Z') });
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },
     );
 
     expect(updatedSlot).not.toEqual(null);
-    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-01T12:00:00.000Z'));
-    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-01T13:00:00.000Z'));
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-02-16T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-16T13:00:00.000Z'));
   });
 
   test('dont edit a timeslot with reservation  if it goes outside reservation range', async () => {
-    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-01-01T12:00:00.000Z'), end: new Date('2023-01-01T14:00:00.000Z') });
+    const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T14:00:00.000Z') });
     const newReservation: Reservation = await Reservation.create({
-      start: new Date('2023-01-01T12:00:00.000Z'),
-      end: new Date('2023-01-01T14:00:00.000Z'),
+      start: new Date('2023-02-16T12:00:00.000Z'),
+      end: new Date('2023-02-16T14:00:00.000Z'),
       aircraftId: 'ESA-111',
       phone: '0501102323',
     });
@@ -170,15 +179,15 @@ describe('Calls to api', () => {
 
     await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
-      .send({ start: '2023-01-01T12:00:00.000Z', end: '2023-01-01T13:00:00.000Z' });
+      .send({ start: '2023-02-16T12:00:00.000Z', end: '2023-02-16T13:00:00.000Z' });
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },
     );
 
     expect(updatedSlot).not.toEqual(null);
-    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-01-01T12:00:00.000Z'));
-    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-01-01T14:00:00.000Z'));
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-02-16T12:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-16T14:00:00.000Z'));
   });
 
   test('can delete a timeslot', async () => {
@@ -203,8 +212,8 @@ describe('Calls to api', () => {
   test('dont delete a timeslot if it has reservations', async () => {
     const createdSlot: Timeslot | null = await Timeslot.findOne({});
     const newReservation: Reservation = await Reservation.create({
-      start: new Date('2023-01-01T12:00:00.000Z'),
-      end: new Date('2023-01-01T13:00:00.000Z'),
+      start: new Date('2023-02-16T12:00:00.000Z'),
+      end: new Date('2023-02-16T13:00:00.000Z'),
       aircraftId: 'ESA-111',
       phone: '0501102323',
     });

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -82,17 +82,29 @@ function Calendar({
     // Open confirmation popup here
     const { event } = changeData;
 
-    await modifyEventFn({
-      id: event.id,
-      start: event.start || new Date(),
-      end: event.end || new Date(),
-    });
+    const eventStartTime: Date = event.start || new Date();
+    const currentTime: Date = new Date();
 
+    if (eventStartTime >= currentTime) {
+      await modifyEventFn({
+        id: event.id,
+        start: event.start || new Date(),
+        end: event.end || new Date(),
+      });
+    }
     calendarRef.current?.getApi().refetchEvents();
   };
 
   // When a new event is selected (dragged) in the calendar.
   const handleEventCreate = async (dropData: DateSelectArg) => {
+    const newStartTime: Date = dropData.start || new Date();
+    const currentTime: Date = new Date();
+
+    if (newStartTime < currentTime) {
+      calendarRef.current?.getApi().unselect();
+      return;
+    }
+
     await addEventFn({
       start: dropData.start,
       end: dropData.end,
@@ -100,6 +112,16 @@ function Calendar({
 
     calendarRef.current?.getApi().refetchEvents();
     calendarRef.current?.getApi().unselect();
+  };
+
+  const validRange = () => {
+    const start = new Date();
+    const end = new Date(start.getTime());
+    end.setMonth(end.getMonth() + 6);
+    return {
+      start,
+      end,
+    };
   };
 
   return (
@@ -140,6 +162,7 @@ function Calendar({
       eventSources={eventSources}
       eventOverlap={areEventsColliding}
       selectOverlap={newEventColliding}
+      validRange={validRange}
     />
   );
 }

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -47,6 +47,10 @@ function Calendar({
         && e.start < span.end && e.end > span.start,
     );
 
+    if (span.start < new Date()) {
+      return false;
+    }
+
     console.log(events);
     return events
       ? countMostConcurrent(events as { start: Date, end: Date }[]) < maxConcurrentLimit
@@ -102,16 +106,6 @@ function Calendar({
     calendarRef.current?.getApi().unselect();
   };
 
-  const validRange = () => {
-    const start = new Date();
-    const end = new Date(start.getTime());
-    end.setMonth(end.getMonth() + 6);
-    return {
-      start,
-      end,
-    };
-  };
-
   return (
     <FullCalendar
       ref={calendarRef}
@@ -149,7 +143,6 @@ function Calendar({
       select={handleEventCreate}
       selectConstraint={selectConstraint}
       eventSources={eventSources}
-      validRange={validRange}
       slotEventOverlap={false}
       selectAllow={allowEvent}
       eventAllow={allowEvent}

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -4,16 +4,21 @@ const minutesToMilliseconds = (minutes: number) => minutes * 1000 * 60;
 const isMultipleOfMinutes = (minutes: number) => (dateToCheck: Date) => (
   dateToCheck.getTime() % minutesToMilliseconds(minutes) === 0
 );
+const isTimeInPast = (time: any): boolean => new Date(time) >= new Date();
 
 const createTimeSlotValidator = (slotGranularityMinutes: number) => {
   const message = `Times must be multiples of ${slotGranularityMinutes} minutes`;
+  const pastErrorMessage = 'Timeslot cannot be in past';
+
   const TimeSlot = z.object({
     start: z.coerce
       .date()
-      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
+      .refine((value) => isTimeInPast(value), { message: pastErrorMessage }),
     end: z.coerce
       .date()
-      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
+      .refine((value) => isTimeInPast(value), { message: pastErrorMessage }),
   });
 
   return TimeSlot;
@@ -21,13 +26,16 @@ const createTimeSlotValidator = (slotGranularityMinutes: number) => {
 
 const createReservationValidator = (slotGranularityMinutes: number) => {
   const message = `Reservation must be multiples of ${slotGranularityMinutes} minutes`;
+  const pastErrorMessage = 'Reservation cannot be in past';
   const Reservation = z.object({
     start: z.coerce
       .date()
-      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
+      .refine((value) => isTimeInPast(value), { message: pastErrorMessage }),
     end: z.coerce
       .date()
-      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
+      .refine((value) => isTimeInPast(value), { message: pastErrorMessage }),
     aircraftId: z.string(),
     info: z.string().optional(),
     phone: z.string(),
@@ -38,13 +46,16 @@ const createReservationValidator = (slotGranularityMinutes: number) => {
 
 const updateReservationValidator = (slotGranularityMinutes: number) => {
   const message = `Reservation must be multiples of ${slotGranularityMinutes} minutes`;
+  const pastErrorMessage = 'Reservation cannot be in past';
   const Reservation = z.object({
     start: z.coerce
       .date()
-      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
+      .refine((value) => isTimeInPast(value), { message: pastErrorMessage }),
     end: z.coerce
       .date()
-      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+      .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
+      .refine((value) => isTimeInPast(value), { message: pastErrorMessage }),
   });
 
   return Reservation;


### PR DESCRIPTION
Related to Issue #

## What changes has been added?

Users cannot add or update a Timeslot or Reservation in the past.

The API tests are broken because their times are mostly hard-coded, and therefore already in the past.

### Backend

Validation ensures that the times are not in the past.

### Frontend

Users cannot drag and drop into the past. I added a validRange to the calendar, which means a user can only add Reservations and Timeslots between now and the next 6 months.

## Expected Behaviour
