### PR TITLE
Add ability to limit concurrent reservations to a hard coded integer value

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -7,7 +7,6 @@ import interactionPlugin from '@fullcalendar/interaction';
 import {
   DateSelectArg, EventChangeArg, EventClickArg, EventSourceInput, OverlapFunc,
 } from '@fullcalendar/core';
-import { EventImpl } from '@fullcalendar/core/internal';
 
 type CalendarProps = {
   calendarRef?: React.RefObject<FullCalendar>;
@@ -38,24 +37,12 @@ function Calendar({
   eventColors,
   selectConstraint,
 }: CalendarProps) {
-  const isOverlap = (eventA: EventImpl, eventB: EventImpl) => {
-    if (eventA.start && eventA.end && eventB.start && eventB.end) {
-      return !(eventA.end <= eventB.start || eventB.end <= eventA.start);
-    }
-    return false;
-  };
   const areEventsColliding: OverlapFunc = (
-    stillEvent: EventImpl,
-    movingEvent: EventImpl | null,
+    stillEvent,
+    movingEvent,
   ) => {
-    if (movingEvent === null) return true;
-    if (stillEvent.groupId === 'timeslots') return true;
-    // TODO: allow overlapping reservations based on airfield maxConcurrentFlights
-    return !(isOverlap(stillEvent, movingEvent) || isOverlap(movingEvent, stillEvent));
-  };
-
-  const newEventColliding: OverlapFunc = (event: EventImpl) => {
-    if (event.groupId === 'timeslots') return true;
+    if (stillEvent.display.includes('background')) return true;
+    if (!movingEvent) return false;
     // TODO: allow overlapping reservations based on airfield maxConcurrentFlights
     return false;
   };
@@ -139,7 +126,7 @@ function Calendar({
       selectConstraint={selectConstraint}
       eventSources={eventSources}
       eventOverlap={areEventsColliding}
-      selectOverlap={newEventColliding}
+      selectOverlap={areEventsColliding}
     />
   );
 }

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -5,12 +5,9 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import listPlugin from '@fullcalendar/list';
 import interactionPlugin from '@fullcalendar/interaction';
 import {
-  AllowFunc,
-  DateSelectArg, EventChangeArg, EventClickArg, EventSourceInput,
+  AllowFunc, DateSelectArg, EventChangeArg, EventClickArg, EventSourceInput,
 } from '@fullcalendar/core';
 import countMostConcurrent from '@lentovaraukset/shared/src/overlap';
-
-const maxConcurrentLimit = 3; // TODO: get from airfield
 
 type CalendarProps = {
   calendarRef?: React.RefObject<FullCalendar>;
@@ -29,6 +26,7 @@ type CalendarProps = {
     textColor?: string;
   } | undefined;
   selectConstraint: string | undefined;
+  maxConcurrentLimit?: number;
 };
 
 function Calendar({
@@ -40,6 +38,7 @@ function Calendar({
   granularity,
   eventColors,
   selectConstraint,
+  maxConcurrentLimit = 1,
 }: CalendarProps) {
   const allowEvent: AllowFunc = (span, movingEvent) => {
     const events = calendarRef.current?.getApi().getEvents().filter(

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -122,6 +122,7 @@ function ReservationCalendar() {
         granularity={{ minutes: 20 }} // TODO: Get from airfield api
         eventColors={{ backgroundColor: '#000000', eventColor: '#FFFFFFF', textColor: '#FFFFFF' }}
         selectConstraint="timeslots"
+        maxConcurrentLimit={3} // TODO: get from airfield api
       />
     </div>
   );

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@lentovaraukset/shared/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist",
     "noImplicitAny": true,
     "module": "es6",

--- a/shared/src/overlap.ts
+++ b/shared/src/overlap.ts
@@ -1,6 +1,4 @@
-import { ReservationEntry, TimeslotEntry } from '.';
-
-const countMostConcurrent = (events: ReservationEntry[] | TimeslotEntry[]) => {
+const countMostConcurrent = (events: { start: Date, end: Date }[]) => {
   let mostConcurrent = 0;
   let currentConcurrent = 0;
 

--- a/shared/src/overlap.ts
+++ b/shared/src/overlap.ts
@@ -1,0 +1,33 @@
+import { ReservationEntry, TimeslotEntry } from '.';
+
+const countMostConcurrent = (events: ReservationEntry[] | TimeslotEntry[]) => {
+  let mostConcurrent = 0;
+  let currentConcurrent = 0;
+
+  const times: { time: Date; isStart: boolean }[] = events.flatMap(
+    (event) => [
+      { time: event.start, isStart: true },
+      { time: event.end, isStart: false }],
+  );
+  times.sort((a, b) => {
+    // If the times are the same, we want to sort the end times first
+    if (a.time.getTime() === b.time.getTime()) {
+      return a.isStart ? 1 : -1;
+    }
+
+    return a.time.getTime() - b.time.getTime();
+  });
+
+  times.forEach((timeObj) => {
+    if (timeObj.isStart) {
+      currentConcurrent += 1;
+      mostConcurrent = Math.max(mostConcurrent, currentConcurrent);
+    } else {
+      currentConcurrent -= 1;
+    }
+  });
+
+  return mostConcurrent;
+};
+
+export default countMostConcurrent;


### PR DESCRIPTION
closes #156 
closes #166 

## What changes has been added?

### Backend

Concurrent limit checking described in #166 fixed. Concurrent limit hardcoded as 3.

### Frontend

Allow concurrent reservations up to a hardcoded limit. Limit set as 3.

## Expected Behaviour
A user can add reservations in any configuration as long as there are no more than 3 concurrent reservations at any moment. It should not be possible to add a 4th reservation.
![image](https://user-images.githubusercontent.com/90393399/221038874-e5d96c42-5b15-4bdc-86ac-b9964711e80d.png)

