### PR TITLE
Add missing reservation route and service fields and typing

### DIFF
--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -123,7 +123,9 @@ describe('Calls to api', () => {
     const phone = createdReservation?.dataValues.phone;
     await api.patch(`/api/reservations/${id}`)
       .set('Content-type', 'application/json')
-      .send({ start: '2023-02-14T02:00:00.000Z', end: '2023-02-14T16:00:00.000Z', aircraftId, phone, });
+      .send({
+        start: '2023-02-14T02:00:00.000Z', end: '2023-02-14T16:00:00.000Z', aircraftId, phone,
+      });
 
     const updatedReservation: Reservation | null = await Reservation.findByPk(id);
 

--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -110,15 +110,21 @@ describe('Calls to api', () => {
   test('can edit a reservation ', async () => {
     const createdReservation: Reservation | null = await Reservation.findOne();
     const id = createdReservation?.dataValues.id;
+    const aircraftId = createdReservation?.dataValues.aircraftId;
+    const phone = createdReservation?.dataValues.phone;
     await api.patch(`/api/reservations/${id}`)
       .set('Content-type', 'application/json')
-      .send({ start: '2023-01-02T02:00:00.000Z', end: '2023-01-02T16:00:00.000Z' });
+      .send({
+        start: '2023-01-02T02:00:00.000Z', end: '2023-01-02T16:00:00.000Z', aircraftId, phone,
+      });
 
     const updatedReservation: Reservation | null = await Reservation.findByPk(id);
 
     expect(updatedReservation).not.toEqual(null);
     expect(updatedReservation?.dataValues.start).toEqual(new Date('2023-01-02T02:00:00.000Z'));
     expect(updatedReservation?.dataValues.end).toEqual(new Date('2023-01-02T16:00:00.000Z'));
+    expect(updatedReservation?.dataValues.aircraftId).toEqual(aircraftId);
+    expect(updatedReservation?.dataValues.phone).toEqual(phone);
   });
 
   test('can get reservations in a range', async () => {

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -45,7 +45,7 @@ const getInTimeRange = async (
         start,
         end,
         aircraftId,
-        reservationInfo,
+        info: reservationInfo,
         phone,
         email: undefined,
         user: 'user',

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -44,16 +44,21 @@ const getInTimeRange = async (
     aircraftId,
     phone,
     info,
-  }) => ({
-    id,
-    start,
-    end,
-    aircraftId,
-    info,
-    phone,
-    email: undefined,
-    user: 'user',
-  }));
+  }) => {
+    const reservationInfo = info ?? undefined;
+    return (
+      {
+        id,
+        start,
+        end,
+        aircraftId,
+        reservationInfo,
+        phone,
+        email: undefined,
+        user: 'user',
+      }
+    );
+  });
 };
 
 const deleteById = async (id: number): Promise<boolean> => {
@@ -76,15 +81,23 @@ const createReservation = async (newReservation: Omit<ReservationEntry, 'id' | '
 
 const updateById = async (
   id: number,
-  reservation: Omit<ReservationEntry, 'id' | 'user'>,
-): Promise<void> => {
+  newReservation: Omit<ReservationEntry, 'id' | 'user'>,
+): Promise<ReservationEntry> => {
   const newTimeslots = await timeslotService
-    .getTimeslotFromRange(reservation.start, reservation.end);
+    .getTimeslotFromRange(newReservation.start, newReservation.end);
   const oldReservation: Reservation | null = await Reservation.findByPk(id);
   const oldTimeslots = await oldReservation?.getTimeslots();
   await oldReservation?.removeTimeslots(oldTimeslots);
   await oldReservation?.addTimeslots(newTimeslots);
-  await Reservation.update(reservation, { where: { id } });
+  const [, reservations]: [number, Reservation[]] = await Reservation.update(
+    newReservation,
+    {
+      where: { id },
+      returning: true,
+    },
+  );
+  const user = 'NYI';
+  return { ...reservations[0].dataValues, user };
 };
 
 export default {

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -17,7 +17,10 @@ const getReservationFromRange = async (startTime: Date, endTime: Date) => {
   return reservations;
 };
 
-const getInTimeRange = async (rangeStartTime: Date, rangeEndTime: Date) => {
+const getInTimeRange = async (
+  rangeStartTime: Date,
+  rangeEndTime: Date,
+): Promise<ReservationEntry[]> => {
   const reservations = await Reservation.findAll({
     where: {
       [Op.or]: [{
@@ -34,8 +37,22 @@ const getInTimeRange = async (rangeStartTime: Date, rangeEndTime: Date) => {
     },
   });
 
-  return reservations.map(({ id, start, end }) => ({
-    title: 'Varattu', id, start, end,
+  return reservations.map(({
+    id,
+    start,
+    end,
+    aircraftId,
+    phone,
+    info,
+  }) => ({
+    id,
+    start,
+    end,
+    aircraftId,
+    info,
+    phone,
+    email: undefined,
+    user: 'user',
   }));
 };
 
@@ -48,12 +65,7 @@ const deleteById = async (id: number): Promise<boolean> => {
   return false;
 };
 
-const createReservation = async (newReservation: {
-  start: Date,
-  end: Date,
-  aircraftId: string,
-  info?: string,
-  phone: string, }): Promise<ReservationEntry> => {
+const createReservation = async (newReservation: Omit<ReservationEntry, 'id' | 'user'>): Promise<ReservationEntry> => {
   const timeslots = await timeslotService
     .getTimeslotFromRange(newReservation.start, newReservation.end);
   const reservation: Reservation = await Reservation.create(newReservation);
@@ -64,7 +76,7 @@ const createReservation = async (newReservation: {
 
 const updateById = async (
   id: number,
-  reservation: { start: Date, end: Date },
+  reservation: Omit<ReservationEntry, 'id' | 'user'>,
 ): Promise<void> => {
   const newTimeslots = await timeslotService
     .getTimeslotFromRange(reservation.start, reservation.end);

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -61,13 +61,13 @@ function Calendar({
   const handleEventClick = async (clickData: EventClickArg) => {
     if (clickData.event.display.includes('background')) return;
     const { event } = clickData;
-    //await clickEventFn({
+    // await clickEventFn({
     //  id: event.id,
     //  start: event.start || undefined,
     //  end: event.start || undefined,
     //  title: event.title,
     //  extendedProps: event.extendedProps,
-    //});
+    // });
     await clickEventFn(event);
   };
 

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -12,13 +12,19 @@ import { EventImpl } from '@fullcalendar/core/internal';
 type CalendarProps = {
   calendarRef?: React.RefObject<FullCalendar>;
   eventSources: EventSourceInput[];
-  addEventFn: (event: { start: Date; end: Date }) => Promise<void>;
-  modifyEventFn: (event: { id: string; start: Date; end: Date }) => Promise<void>;
+  addEventFn: (event: { start: Date; end: Date; }) => Promise<any>;
+  modifyEventFn: (event: {
+    id: string;
+    start: Date;
+    end: Date,
+    extendedProps: any }) => Promise<any>;
   clickEventFn: (event: {
     id: string;
     start?: Date;
     end?: Date;
-    title?: string }) => Promise<void>;
+    title?: string;
+    extendedProps: any
+  }) => Promise<void>;
   granularity: { minutes: number };
   eventColors: {
     backgroundColor?: string;
@@ -71,6 +77,7 @@ function Calendar({
       start: event.start || undefined,
       end: event.start || undefined,
       title: event.title,
+      extendedProps: event.extendedProps,
     });
 
     // Refresh calendar if changes were made
@@ -86,6 +93,7 @@ function Calendar({
       id: event.id,
       start: event.start || new Date(),
       end: event.end || new Date(),
+      extendedProps: event.extendedProps,
     });
 
     calendarRef.current?.getApi().refetchEvents();

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -55,7 +55,6 @@ function Calendar({
       return false;
     }
 
-    console.log(events);
     return events
       ? countMostConcurrent(events as { start: Date, end: Date }[]) < maxConcurrentLimit
       : true;

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -61,13 +61,6 @@ function Calendar({
   const handleEventClick = async (clickData: EventClickArg) => {
     if (clickData.event.display.includes('background')) return;
     const { event } = clickData;
-    // await clickEventFn({
-    //  id: event.id,
-    //  start: event.start || undefined,
-    //  end: event.start || undefined,
-    //  title: event.title,
-    //  extendedProps: event.extendedProps,
-    // });
     await clickEventFn(event);
   };
 

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -120,7 +120,7 @@ function ReservationCalendar() {
             <p className="text-2xl pb-2">Varaus</p>
             <pre>
               {
-                JSON.stringify(selectedReservationRef, null, 2)
+                JSON.stringify(selectedReservationRef.current, null, 2)
               }
             </pre>
           </div>

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -32,7 +32,17 @@ function ReservationCalendar() {
       const reservations = await getReservations(start, end);
 
       const reservationsMapped = reservations.map((reservation) => ({
-        ...reservation, constraint: 'timeslots',
+        ...reservation,
+        id: reservation.id.toString(),
+        title: reservation.aircraftId,
+        constraint: 'timeslots',
+        extendedProps: {
+          user: reservation.user,
+          aircraftId: reservation.aircraftId,
+          phone: reservation.phone,
+          email: reservation.email,
+          info: reservation.info,
+        },
       }));
 
       successCallback(reservationsMapped);
@@ -78,6 +88,28 @@ function ReservationCalendar() {
     calendarRef.current?.getApi().refetchEvents();
   };
 
+  const modifyReservationFn = async (event: {
+    id: string;
+    start: Date;
+    end: Date,
+    extendedProps: any
+  }): Promise<void> => {
+    const {
+      user, aircraftId, phone, email, info,
+    } = event.extendedProps;
+
+    await modifyReservation({
+      id: parseInt(event.id, 10),
+      start: event.start,
+      end: event.end,
+      user,
+      aircraftId,
+      phone,
+      email,
+      info,
+    });
+  };
+
   return (
     <div className="flex flex-col space-y-2 h-full w-full">
       <Card show={showInspectModal} handleClose={closeReservationModalFn}>
@@ -117,7 +149,7 @@ function ReservationCalendar() {
         calendarRef={calendarRef}
         eventSources={[reservationsSourceFn, timeSlotsSourceFn]}
         addEventFn={addReservation}
-        modifyEventFn={modifyReservation}
+        modifyEventFn={modifyReservationFn}
         clickEventFn={clickReservation}
         granularity={{ minutes: 20 }} // TODO: Get from airfield api
         eventColors={{ backgroundColor: '#000000', eventColor: '#FFFFFFF', textColor: '#FFFFFF' }}

--- a/frontend/src/queries/reservations.ts
+++ b/frontend/src/queries/reservations.ts
@@ -1,18 +1,19 @@
-import { EventInput } from '@fullcalendar/core';
+import { ReservationEntry } from '@lentovaraukset/shared/src';
 
-const getReservations = async (from: Date, until: Date): Promise<EventInput[]> => {
+const getReservations = async (from: Date, until: Date): Promise<ReservationEntry[]> => {
   const res = await fetch(`${process.env.BASE_PATH}/api/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
   return res.json();
 };
 
-const addReservation = async (newReservation: any): Promise<void> => {
-  await fetch(`${process.env.BASE_PATH}/api/reservations/`, {
+const addReservation = async (newReservation: any): Promise<ReservationEntry> => {
+  const res = await fetch(`${process.env.BASE_PATH}/api/reservations/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ ...newReservation, aircraftId: '1', phone: '1' }),
+    body: JSON.stringify({ ...newReservation, aircraftId: 'OH-EXMPL', phone: '051 123 4567' }),
   });
+  return res.json();
 };
 
 const deleteReservation = async (id: Number): Promise<string> => {
@@ -25,11 +26,7 @@ const deleteReservation = async (id: Number): Promise<string> => {
   return response.text();
 };
 
-const modifyReservation = async (reservation:{
-  id: string,
-  start: Date,
-  end: Date,
-}): Promise<void> => {
+const modifyReservation = async (reservation: ReservationEntry): Promise<ReservationEntry> => {
   const modifiedReservation = {
     start: reservation.start,
     end: reservation.end,

--- a/frontend/src/queries/reservations.ts
+++ b/frontend/src/queries/reservations.ts
@@ -26,12 +26,10 @@ const deleteReservation = async (id: Number): Promise<string> => {
   return response.text();
 };
 
-const modifyReservation = async (reservation: ReservationEntry): Promise<ReservationEntry> => {
-  const modifiedReservation = {
-    start: reservation.start,
-    end: reservation.end,
-  };
-  const res = await fetch(`${process.env.BASE_PATH}/api/reservations/${reservation.id}`, {
+const modifyReservation = async (
+  modifiedReservation: ReservationEntry,
+): Promise<ReservationEntry> => {
+  const res = await fetch(`${process.env.BASE_PATH}/api/reservations/${modifiedReservation.id}`, {
     method: 'PATCH',
     body: JSON.stringify(modifiedReservation),
     headers: {

--- a/frontend/src/queries/reservations.ts
+++ b/frontend/src/queries/reservations.ts
@@ -11,7 +11,9 @@ const addReservation = async (newReservation: any): Promise<ReservationEntry> =>
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ ...newReservation, aircraftId: 'OH-EXMPL', phone: '051 123 4567' }),
+    body: JSON.stringify({
+      ...newReservation, aircraftId: 'OH-EXMPL', phone: '051 123 4567', info: 'placeholder',
+    }),
   });
   return res.json();
 };

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,7 +6,7 @@ export interface ReservationEntry {
   aircraftId: string;
   phone: string;
   email?: string;
-  info: string;
+  info?: string;
 }
 
 export interface TimeslotEntry {

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -45,6 +45,9 @@ const updateReservationValidator = (slotGranularityMinutes: number) => {
     end: z.coerce
       .date()
       .refine(isMultipleOfMinutes(slotGranularityMinutes), { message }),
+    aircraftId: z.string(),
+    info: z.string().optional(),
+    phone: z.string(),
   });
 
   return Reservation;


### PR DESCRIPTION
Related to Issue #154 

## What changes has been added?

Added missing reservation route and service fields according to shared type ReservationEntry. Refactored several functions to use the mentioned type in the backend and frontend. Changed affected queries and calendar handlers accordingly.

### Backend

- reservationService functions have appropriate return and parameter types.
- getInTimeRange & /api/reservations GET returns aircraftId, info, phone, email and user
- updateById allows & /api/reservations PATCH allows changing aircraftId, phone and info

### Frontend
- query functions have appropriate return and paramerer types

## Expected Behaviour
- reservation info window should now include extendedProps with placeholder user, aircraftId, phone and info
![image](https://user-images.githubusercontent.com/56773501/221410101-6719f8c9-5fe2-48e1-9520-a592dba01c5f.png)
