### PR TITLE
Get configuration from db in backend

### DIFF
--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -1,7 +1,8 @@
 import request from 'supertest';
 import app from '@lentovaraukset/backend/src/index';
 import { Reservation } from '@lentovaraukset/backend/src/models';
-import { connectToDatabase, createTestAirfield, sequelize } from '../src/util/db';
+import { connectToDatabase, sequelize } from '../src/util/db';
+import airfieldService from '../src/services/airfieldService';
 
 const api = request(app);
 
@@ -49,7 +50,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   // wipe db before each test
   await sequelize.truncate({ cascade: true });
-  await createTestAirfield();
+  await airfieldService.createTestAirfield();
   await Reservation.bulkCreate(reservations);
 });
 

--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '@lentovaraukset/backend/src/index';
 import { Reservation } from '@lentovaraukset/backend/src/models';
-import { connectToDatabase, sequelize } from '../src/util/db';
+import { connectToDatabase, createTestAirfield, sequelize } from '../src/util/db';
 
 const api = request(app);
 
@@ -49,6 +49,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   // wipe db before each test
   await sequelize.truncate({ cascade: true });
+  await createTestAirfield();
   await Reservation.bulkCreate(reservations);
 });
 

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -1,7 +1,8 @@
 import request from 'supertest';
 import app from '@lentovaraukset/backend/src/index';
 import { Reservation, Timeslot } from '@lentovaraukset/backend/src/models';
-import { connectToDatabase, createTestAirfield, sequelize } from '../src/util/db';
+import { connectToDatabase, sequelize } from '../src/util/db';
+import airfieldService from '../src/services/airfieldService';
 
 const api = request(app);
 
@@ -31,7 +32,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   // wipe db before each test
   await sequelize.truncate({ cascade: true });
-  await createTestAirfield();
+  await airfieldService.createTestAirfield();
   await Timeslot.bulkCreate(timeslotData);
 });
 
@@ -100,11 +101,9 @@ describe('Calls to api', () => {
   test('can edit a timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z') });
 
-    const res = await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({ start: '2023-02-17T12:00:00.000Z', end: '2023-02-17T14:00:00.000Z' });
-
-    console.log(res.body);
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '@lentovaraukset/backend/src/index';
 import { Reservation, Timeslot } from '@lentovaraukset/backend/src/models';
-import { connectToDatabase, sequelize } from '../src/util/db';
+import { connectToDatabase, createTestAirfield, sequelize } from '../src/util/db';
 
 const api = request(app);
 
@@ -31,6 +31,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   // wipe db before each test
   await sequelize.truncate({ cascade: true });
+  await createTestAirfield();
   await Timeslot.bulkCreate(timeslotData);
 });
 
@@ -99,9 +100,11 @@ describe('Calls to api', () => {
   test('can edit a timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z') });
 
-    await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
+    const res = await api.patch(`/api/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({ start: '2023-02-17T12:00:00.000Z', end: '2023-02-17T14:00:00.000Z' });
+
+    console.log(res.body);
 
     const updatedSlot: Timeslot | null = await Timeslot.findOne(
       { where: { id: createdSlot.dataValues.id } },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,8 @@
 import app from './index';
 import { connectToDatabase } from './util/db';
 import { PORT } from './util/config';
+import airfieldService from './services/airfieldService';
 
-connectToDatabase();
+connectToDatabase().then(airfieldService.createTestAirfield);
+
 app.listen(PORT, () => console.log(`Server is running on port: ${PORT}`));

--- a/backend/src/models/airfield.ts
+++ b/backend/src/models/airfield.ts
@@ -17,6 +17,8 @@ InferCreationAttributes<Airfield>
   declare name: string;
 
   declare maxConcurrentFlights: number;
+
+  declare eventGranularityMinutes: number;
 }
 
 Airfield.init(
@@ -32,6 +34,10 @@ Airfield.init(
       unique: true,
     },
     maxConcurrentFlights: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    eventGranularityMinutes: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { createTimeSlotValidator, getTimeRangeValidator } from '@lentovaraukset/shared/src/validation/validation';
 import timeslotService from '../services/timeslotService';
+import airfieldService from '../services/airfieldService';
 
 const router = express.Router();
 
@@ -29,8 +30,9 @@ router.delete('/:id', async (req: express.Request, res: express.Response) => {
 
 router.post('/', async (req: express.Request, res: express.Response) => {
   try {
-    // TODO: get slotGranularityMinutes from airfield
-    const newTimeSlot = createTimeSlotValidator(20).parse(req.body);
+    const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
+    const newTimeSlot = createTimeSlotValidator(airfield.eventGranularityMinutes).parse(req.body);
+    // TODO: check if timeslot overlaps with existing timeslots
 
     const timeslot = await timeslotService.createTimeslot(newTimeSlot);
     res.json(timeslot);
@@ -43,8 +45,10 @@ router.post('/', async (req: express.Request, res: express.Response) => {
 
 router.patch('/:id', async (req: express.Request, res: express.Response) => {
   try {
-    // TODO: get slotGranularityMinutes from airfield
-    const modifiedTimeslot = createTimeSlotValidator(20).parse(req.body);
+    const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
+    const modifiedTimeslot = createTimeSlotValidator(airfield.eventGranularityMinutes)
+      .parse(req.body);
+    // TODO: check if timeslot overlaps with existing timeslots
 
     const id = Number(req.params.id);
     await timeslotService.updateById(id, modifiedTimeslot);

--- a/backend/src/services/airfieldService.ts
+++ b/backend/src/services/airfieldService.ts
@@ -1,0 +1,25 @@
+import { Airfield } from '../models';
+
+const getAirfield = async (id: number): Promise<Airfield> => {
+  const airfield = await Airfield.findOne({
+    where: {
+      id,
+    },
+  });
+
+  if (!airfield) {
+    throw new Error('Airfield not found');
+  }
+
+  return airfield;
+};
+
+const getAirfields = async (): Promise<Airfield[]> => {
+  const airfields = await Airfield.findAll();
+  return airfields;
+};
+
+export default {
+  getAirfield,
+  getAirfields,
+};

--- a/backend/src/services/airfieldService.ts
+++ b/backend/src/services/airfieldService.ts
@@ -19,7 +19,18 @@ const getAirfields = async (): Promise<Airfield[]> => {
   return airfields;
 };
 
+const createTestAirfield = async () => {
+  // TODO: Remove this when we have a proper admin interface for creating airfields
+  await Airfield.upsert({
+    id: 1,
+    name: 'Test Airfield',
+    maxConcurrentFlights: 3,
+    eventGranularityMinutes: 20,
+  });
+};
+
 export default {
   getAirfield,
   getAirfields,
+  createTestAirfield,
 };

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -1,10 +1,7 @@
 import { Op } from 'sequelize';
 import { ReservationEntry } from '@lentovaraukset/shared/src';
-import countMostConcurrent from '@lentovaraukset/shared/src/overlap';
 import timeslotService from '@lentovaraukset/backend/src/services/timeslotService';
 import { Reservation } from '../models';
-
-const maxConcurrentReservations: number = 3;
 
 const getReservationFromRange = async (startTime: Date, endTime: Date) => {
   const reservations: Reservation[] = await Reservation.findAll({
@@ -54,19 +51,6 @@ const getInTimeRange = async (
   });
 };
 
-const allowReservation = async (
-  startTime: Date,
-  endTime: Date,
-  id: number | undefined,
-): Promise<boolean> => {
-  const reservations = (await getReservationFromRange(startTime, endTime))
-    .filter((e) => e.id !== id);
-
-  const mostConcurrentReservations = countMostConcurrent(reservations);
-
-  return mostConcurrentReservations < maxConcurrentReservations;
-};
-
 const deleteById = async (id: number) => {
   const reservation = await Reservation.findByPk(id);
   if (!reservation) {
@@ -76,41 +60,33 @@ const deleteById = async (id: number) => {
 };
 
 const createReservation = async (newReservation: Omit<ReservationEntry, 'id' | 'user'>): Promise<ReservationEntry> => {
-  if (!await allowReservation(newReservation.start, newReservation.end, undefined)) {
-    throw new Error('Too many concurrent reservations');
-  } else {
-    const timeslots = await timeslotService
-      .getTimeslotFromRange(newReservation.start, newReservation.end);
-    const reservation: Reservation = await Reservation.create(newReservation);
-    await reservation.addTimeslots(timeslots);
-    const user = 'NYI';
-    return { ...reservation.dataValues, user };
-  }
+  const timeslots = await timeslotService
+    .getTimeslotFromRange(newReservation.start, newReservation.end);
+  const reservation: Reservation = await Reservation.create(newReservation);
+  await reservation.addTimeslots(timeslots);
+  const user = 'NYI';
+  return { ...reservation.dataValues, user };
 };
 
 const updateById = async (
   id: number,
   reservation: Omit<ReservationEntry, 'id' | 'user'>,
 ): Promise<ReservationEntry> => {
-  if (!await allowReservation(reservation.start, reservation.end, id)) {
-    throw new Error('Too many concurrent reservations');
-  } else {
-    const newTimeslots = await timeslotService
-      .getTimeslotFromRange(reservation.start, reservation.end);
-    const oldReservation: Reservation | null = await Reservation.findByPk(id);
-    const oldTimeslots = await oldReservation?.getTimeslots();
-    await oldReservation?.removeTimeslots(oldTimeslots);
-    await oldReservation?.addTimeslots(newTimeslots);
-    const [, reservations]: [number, Reservation[]] = await Reservation.update(
-      reservation,
-      {
-        where: { id },
-        returning: true,
-      },
-    );
-    const user = 'NYI';
-    return { ...reservations[0].dataValues, user };
-  }
+  const newTimeslots = await timeslotService
+    .getTimeslotFromRange(reservation.start, reservation.end);
+  const oldReservation: Reservation | null = await Reservation.findByPk(id);
+  const oldTimeslots = await oldReservation?.getTimeslots();
+  await oldReservation?.removeTimeslots(oldTimeslots);
+  await oldReservation?.addTimeslots(newTimeslots);
+  const [, reservations]: [number, Reservation[]] = await Reservation.update(
+    reservation,
+    {
+      where: { id },
+      returning: true,
+    },
+  );
+  const user = 'NYI';
+  return { ...reservations[0].dataValues, user };
 };
 
 export default {

--- a/backend/src/util/db.ts
+++ b/backend/src/util/db.ts
@@ -1,22 +1,10 @@
 import { Sequelize } from 'sequelize';
 import { newDb } from 'pg-mem';
 import { DATABASE_URL } from './config';
-// eslint-disable-next-line import/no-cycle
-import { Airfield } from '../models';
 
 if (process.env.NODE_ENV === 'test') {
   console.log('creating an in-memory test database');
 }
-
-const createTestAirfield = async () => {
-  // TODO: Remove this when we have a proper admin interface for creating airfields
-  await Airfield.upsert({
-    id: 1,
-    name: 'Test Airfield',
-    maxConcurrentFlights: 3,
-    eventGranularityMinutes: 20,
-  });
-};
 
 const sequelize = process.env.NODE_ENV === 'test'
   ? new Sequelize({ dialect: 'postgres', dialectModule: newDb().adapters.createPg(), logging: false })
@@ -27,7 +15,6 @@ const connectToDatabase = async () => {
     await sequelize.sync({ alter: true });
     await sequelize.authenticate();
     console.log('database connected');
-    createTestAirfield();
   } catch (err) {
     console.log('connecting database failed. error:', err);
     return process.exit(1);
@@ -36,4 +23,4 @@ const connectToDatabase = async () => {
   return null;
 };
 
-export { connectToDatabase, sequelize, createTestAirfield };
+export { connectToDatabase, sequelize };

--- a/backend/src/util/db.ts
+++ b/backend/src/util/db.ts
@@ -1,10 +1,22 @@
 import { Sequelize } from 'sequelize';
 import { newDb } from 'pg-mem';
 import { DATABASE_URL } from './config';
+// eslint-disable-next-line import/no-cycle
+import { Airfield } from '../models';
 
 if (process.env.NODE_ENV === 'test') {
   console.log('creating an in-memory test database');
 }
+
+const createTestAirfield = () => {
+  // TODO: Remove this when we have a proper admin interface for creating airfields
+  Airfield.upsert({
+    id: 1,
+    name: 'Test Airfield',
+    maxConcurrentFlights: 3,
+    eventGranularityMinutes: 20,
+  });
+};
 
 const sequelize = process.env.NODE_ENV === 'test'
   ? new Sequelize({ dialect: 'postgres', dialectModule: newDb().adapters.createPg(), logging: false })
@@ -15,6 +27,7 @@ const connectToDatabase = async () => {
     await sequelize.sync({ alter: true });
     await sequelize.authenticate();
     console.log('database connected');
+    createTestAirfield();
   } catch (err) {
     console.log('connecting database failed. error:', err);
     return process.exit(1);

--- a/backend/src/util/db.ts
+++ b/backend/src/util/db.ts
@@ -8,9 +8,9 @@ if (process.env.NODE_ENV === 'test') {
   console.log('creating an in-memory test database');
 }
 
-const createTestAirfield = () => {
+const createTestAirfield = async () => {
   // TODO: Remove this when we have a proper admin interface for creating airfields
-  Airfield.upsert({
+  await Airfield.upsert({
     id: 1,
     name: 'Test Airfield',
     maxConcurrentFlights: 3,
@@ -36,4 +36,4 @@ const connectToDatabase = async () => {
   return null;
 };
 
-export { connectToDatabase, sequelize };
+export { connectToDatabase, sequelize, createTestAirfield };


### PR DESCRIPTION
Related to Issue #159 

## What changes has been added?

### Backend

A test airfield is added to the db at startup. This is a placeholder until there is functionality to add airfields.
The backend now gets the concurrent flights and event granularity limits from the test airfield in the db.

### Frontend

## Expected Behaviour
