### PR TITLE
Frontend: get airfield config from backend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import timeslotRouter from './routes/timeslots';
 import reservationRouter from './routes/reservations';
+import airfieldRouter from './routes/airfields';
 import errorHandler from './util/middleware';
 
 const app = express();
@@ -13,6 +14,7 @@ app.get('/api', async (_req: any, res: express.Response) => {
 });
 app.use('/api/timeslots', timeslotRouter);
 app.use('/api/reservations', reservationRouter);
+app.use('/api/airfields', airfieldRouter);
 app.use(errorHandler);
 
 export default app;

--- a/backend/src/routes/airfields.ts
+++ b/backend/src/routes/airfields.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import airfieldService from '../services/airfieldService';
+
+const router = express.Router();
+
+router.get('/', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  try {
+    const airfields = await airfieldService.getAirfields();
+    res.json(airfields);
+  } catch (error: unknown) {
+    console.log(error);
+    next(error);
+  }
+});
+
+router.get('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const id = Number(req.params.id);
+  try {
+    const airfield = await airfieldService.getAirfield(id);
+    res.json(airfield);
+  } catch (error: unknown) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/services/airfieldService.ts
+++ b/backend/src/services/airfieldService.ts
@@ -1,6 +1,7 @@
+import { AirfieldEntry } from '@lentovaraukset/shared/src';
 import { Airfield } from '../models';
 
-const getAirfield = async (id: number): Promise<Airfield> => {
+const getAirfield = async (id: number): Promise<AirfieldEntry> => {
   const airfield = await Airfield.findOne({
     where: {
       id,
@@ -11,12 +12,12 @@ const getAirfield = async (id: number): Promise<Airfield> => {
     throw new Error('Airfield not found');
   }
 
-  return airfield;
+  return airfield.dataValues;
 };
 
-const getAirfields = async (): Promise<Airfield[]> => {
+const getAirfields = async (): Promise<AirfieldEntry[]> => {
   const airfields = await Airfield.findAll();
-  return airfields;
+  return airfields.map((airfield) => airfield.dataValues);
 };
 
 const createTestAirfield = async () => {

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -20,7 +20,7 @@ type CalendarProps = {
     extendedProps: any }) => Promise<any>;
   clickEventFn: (event: EventImpl) => Promise<void>;
   removeEventFn: (event: EventRemoveArg) => Promise<void>;
-  granularity: { minutes: number };
+  granularity: { minutes: number } | undefined;
   eventColors: {
     backgroundColor?: string;
     eventColor?: string;
@@ -36,7 +36,7 @@ function Calendar({
   modifyEventFn,
   clickEventFn,
   removeEventFn,
-  granularity,
+  granularity = { minutes: 20 },
   eventColors,
   selectConstraint,
   maxConcurrentLimit = 1,

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -10,10 +10,13 @@ import {
 } from '../queries/reservations';
 import Card from '../components/Card';
 import { getTimeSlots } from '../queries/timeSlots';
+import useAirfield from '../queries/airfields';
 
 function ReservationCalendar() {
   const [showInspectModal, setShowInspectModal] = useState(false);
   const selectedReservationRef = useRef<EventImpl | null>(null);
+
+  const { data: airfield } = useAirfield(1); // TODO: get id from airfield selection
 
   const reservationsSourceFn: EventSourceFunc = async (
     { start, end },
@@ -147,10 +150,10 @@ function ReservationCalendar() {
         modifyEventFn={modifyReservationFn}
         clickEventFn={clickReservation}
         removeEventFn={removeReservation}
-        granularity={{ minutes: 20 }} // TODO: Get from airfield api
+        granularity={airfield && { minutes: airfield.eventGranularityMinutes }}
         eventColors={{ backgroundColor: '#000000', eventColor: '#FFFFFFF', textColor: '#FFFFFF' }}
         selectConstraint="timeslots"
-        maxConcurrentLimit={3} // TODO: get from airfield api
+        maxConcurrentLimit={airfield?.maxConcurrentFlights}
       />
     </div>
   );

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -2,6 +2,7 @@ import { EventRemoveArg, EventSourceFunc } from '@fullcalendar/core';
 import { EventImpl } from '@fullcalendar/core/internal';
 import React from 'react';
 import Calendar from '../components/Calendar';
+import useAirfield from '../queries/airfields';
 import {
   getReservations,
 } from '../queries/reservations';
@@ -10,6 +11,8 @@ import {
 } from '../queries/timeSlots';
 
 function TimeSlotCalendar() {
+  const { data: airfield } = useAirfield(1); // TODO: get id from airfield selection
+
   const timeSlotsSourceFn: EventSourceFunc = async (
     { start, end },
     successCallback,
@@ -65,7 +68,7 @@ function TimeSlotCalendar() {
         modifyEventFn={modifyTimeSlot}
         clickEventFn={clickEventFn}
         removeEventFn={removeTimeSlot}
-        granularity={{ minutes: 20 }} // TODO: Get from airfield api
+        granularity={airfield && { minutes: airfield.eventGranularityMinutes }}
         eventColors={{ backgroundColor: '#bef264', eventColor: '#84cc1680', textColor: '#000000' }}
         selectConstraint={undefined}
         maxConcurrentLimit={1}

--- a/frontend/src/queries/airfields.ts
+++ b/frontend/src/queries/airfields.ts
@@ -1,0 +1,15 @@
+import { AirfieldEntry } from '@lentovaraukset/shared/src';
+import { useQuery } from 'react-query';
+import QueryKeys from './queryKeys';
+
+const getAirfields = async (airfieldId: number): Promise<AirfieldEntry> => {
+  const res = await fetch(`${process.env.BASE_PATH}/api/airfields/${airfieldId}`);
+  return res.json();
+};
+
+const useAirfield = (airfieldId: number) => useQuery(
+  [QueryKeys.Airfield, airfieldId],
+  () => getAirfields(airfieldId),
+);
+
+export default useAirfield;

--- a/frontend/src/queries/queryKeys.ts
+++ b/frontend/src/queries/queryKeys.ts
@@ -3,6 +3,7 @@ enum QueryKeys {
   ReservationStatus = 'reservationStatus',
   Reservations = 'reservations',
   TimeSlots = 'timeslots',
+  Airfield = 'airfield',
 }
 
 export default QueryKeys;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -14,3 +14,10 @@ export interface TimeslotEntry {
   start: Date;
   end: Date;
 }
+
+export interface AirfieldEntry {
+  id: number;
+  name: string;
+  maxConcurrentFlights: number;
+  eventGranularityMinutes: number;
+}


### PR DESCRIPTION
Related to Issue #157 

## What changes has been added?

### Backend

Added routes for fetching airfields

### Frontend

Airfield 1 is fetched from the backend and used to configure event granularity and max concurrent flights in the calendars.

## Expected Behaviour

Changing the settings of field 1 in the db should change the constraints in the frontend.
