### PR TITLE
prevent consecutive timeslots in backend

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -29,6 +29,7 @@ type CalendarProps = {
   } | undefined;
   selectConstraint: string | undefined;
   maxConcurrentLimit?: number;
+  allowEventRef?: AllowFunc;
 };
 
 function Calendar({
@@ -42,6 +43,7 @@ function Calendar({
   eventColors,
   selectConstraint,
   maxConcurrentLimit = 1,
+  allowEventRef = () => true,
 }: CalendarProps) {
   const calendarRef = forwardedCalendarRef || React.createRef();
 
@@ -150,8 +152,8 @@ function Calendar({
       selectConstraint={selectConstraint}
       eventSources={eventSources}
       slotEventOverlap={false}
-      selectAllow={allowEvent}
-      eventAllow={allowEvent}
+      selectAllow={(s, m) => allowEvent(s, m) && allowEventRef(s, m)}
+      eventAllow={(s, m) => allowEvent(s, m) && allowEventRef(s, m)}
     />
   );
 }

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -114,6 +114,8 @@ function Calendar({
     calendarRef.current?.getApi().unselect();
   };
 
+  const handleAllow: AllowFunc = (s, m) => allowEvent(s, m) && allowEventRef(s, m);
+
   return (
     <FullCalendar
       ref={calendarRef}
@@ -152,8 +154,8 @@ function Calendar({
       selectConstraint={selectConstraint}
       eventSources={eventSources}
       slotEventOverlap={false}
-      selectAllow={(s, m) => allowEvent(s, m) && allowEventRef(s, m)}
-      eventAllow={(s, m) => allowEvent(s, m) && allowEventRef(s, m)}
+      selectAllow={handleAllow}
+      eventAllow={handleAllow}
     />
   );
 }

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -64,6 +64,7 @@ function TimeSlotCalendar() {
   const allowEvent: AllowFunc = (span, movingEvent) => {
     const timeIsConsecutive = calendarRef.current?.getApi().getEvents().some(
       (e) => e.id !== movingEvent?.id
+        && e.groupId !== 'reservations'
         && e.start && e.end
         && (e.start.getTime() === span.start.getTime()
           || e.start.getTime() === span.end.getTime()


### PR DESCRIPTION
Related to Issue #

## What changes has been added?

### Backend

Prevent update and new timeslot, if Timeslot is consecutive.

### Frontend

Prevent selection and drop if Timeslot is consecutive with some Timeslot.

## Expected Behaviour
