### PR TITLE
modal for timeslots

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -20,7 +20,7 @@ function Card({
   return (
     <Modal show={show} handleClose={handleClose}>
       <div
-        className=" flex flex-col max-w-md h-fit bg-white rounded-lg shadow-2xl overflow-hidden"
+        className=" flex flex-col max-w-fit h-fit bg-white rounded-lg shadow-2xl overflow-hidden"
       >
         {Children.toArray(children)[0]}
         {(Children.count(children) > 1 || cancelButton)

--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -68,7 +68,6 @@ function InputField({
         id={id}
         type={type}
         value={value}
-        onChange={onChange}
         disabled={state === 'disabled'}
         placeholder={placeholder}
         className={`${fieldBaseClass} ${fieldStateClasses[state]} ${inputClassName}`}
@@ -78,6 +77,7 @@ function InputField({
         // are complicated to do
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...registerReturn}
+        onChange={onChange}
       />
       {helperText ? <p className={`text-ft-text-300 -mt-4 ${helperTextClassName}`}>{helperText}</p> : null}
     </div>

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -39,10 +39,9 @@ function RecurringTimeslotForm({
     const updatedTimeslot = {
       start: new Date(formData.start),
       end: new Date(formData.end),
-      isRecurring: formData.isRecurring,
-      periodStarts: formData.periodStarts,
-      periodEnds: formData.periodEnds,
     };
+    // TODO: create recurring events if possible
+    // const { isRecurring, periodStarts, periodEnds } = formData;
     onSubmit(updatedTimeslot);
   };
   const onError = (e: any) => console.error(e);
@@ -78,6 +77,20 @@ function RecurringTimeslotForm({
                   type="datetime-local"
                   registerReturn={register('start')}
                 />
+                <InputField
+                  labelText="Määritä toistuvuus"
+                  type="checkbox"
+                  onChange={() => setShowRecurring(!showRecurring)}
+                  registerReturn={register('isRecurring')}
+                />
+                {showRecurring && (
+                <InputField
+                  labelText="Alkaa:"
+                  type="date"
+                  inputClassName="w-full"
+                  registerReturn={register('periodStarts')}
+                />
+                )}
               </div>
               <div className="flex flex-col">
                 <InputField
@@ -85,35 +98,17 @@ function RecurringTimeslotForm({
                   type="datetime-local"
                   registerReturn={register('end')}
                 />
-              </div>
-            </div>
-            <InputField
-              labelText="Määritä toistuvuus"
-              type="checkbox"
-              onChange={() => {
-                console.log('moi');
-                setShowRecurring(!showRecurring);
-              }}
-              registerReturn={register('isRecurring')}
-            />
-            {showRecurring && (
-            <div className="flex flex-row space-x-6">
-              <div className="flex flex-col">
-                <InputField
-                  labelText="Alkaa:"
-                  type="date"
-                  registerReturn={register('periodStarts')}
-                />
-              </div>
-              <div className="flex flex-col">
+                <div className="flex-1" />
+                {showRecurring && (
                 <InputField
                   labelText="Päättyy:"
                   type="date"
+                  inputClassName="w-full"
                   registerReturn={register('periodEnds')}
                 />
+                )}
               </div>
             </div>
-            )}
           </form>
           )
         }

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect } from 'react';
+import { EventImpl } from '@fullcalendar/core/internal';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { TimeslotEntry } from '@lentovaraukset/shared/src';
+import InputField from '../InputField';
+
+type RecurringTimeslotProps = {
+  timeslot?: EventImpl
+  onSubmit: (formData: Omit<TimeslotEntry, 'id' | 'user'>) => void
+  id?: string
+};
+
+type Inputs = {
+  start: string
+  end: string
+  recurring: string
+};
+
+function RecurringTimeslotForm({
+  timeslot,
+  onSubmit,
+  id,
+}: RecurringTimeslotProps) {
+  const {
+    register, handleSubmit, reset,
+  } = useForm<Inputs>({
+    values: {
+      start: timeslot?.startStr.replace(/.{3}\+.*/, '') || '',
+      end: timeslot?.endStr.replace(/.{3}\+.*/, '') || '',
+      recurring: 'Ei toistu',
+    },
+  });
+  const submitHandler: SubmitHandler<Inputs> = async (formData) => {
+    const updatedTimeslot = {
+      start: new Date(formData.start),
+      end: new Date(formData.end),
+      recurring: formData.recurring,
+    };
+
+    onSubmit(updatedTimeslot);
+  };
+  const onError = (e: any) => console.error(e);
+
+  useEffect(() => {
+    reset();
+  }, [timeslot]);
+
+  return (
+    <div>
+      <div className="bg-black p-3">
+        <p className="text-white">
+          {
+        timeslot
+          ? `Aikaikkuna #${timeslot.id}`
+          : 'Virhe'
+        }
+        </p>
+      </div>
+      <div className="p-8">
+        {
+          !timeslot
+          && <p>Virhe aikaikkunaa haettaessa</p>
+        }
+        {
+          timeslot
+          && (
+          /* eslint-disable  react/jsx-props-no-spreading */
+          <form id={id} className="flex flex-col w-fit" onSubmit={handleSubmit(submitHandler, onError)}>
+            <div className="flex flex-row space-x-6">
+              <div className="flex flex-col">
+                <InputField
+                  labelText="Aikaikkuna alkaa:"
+                  type="datetime-local"
+                  registerReturn={register('start')}
+                />
+              </div>
+              <div className="flex flex-col">
+                <InputField
+                  labelText="Aikaikkuna päättyy:"
+                  type="datetime-local"
+                  registerReturn={register('end')}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col">
+              <p>
+                Toistuvuus:
+              </p>
+              <select name="recurring-events">
+                <option value="none">Ei toistu</option>
+                <option value="weekdays">Arkipäivisin</option>
+              </select>
+            </div>
+          </form>
+          /* eslint-enable  react/jsx-props-no-spreading */
+          )
+        }
+      </div>
+    </div>
+  );
+}
+
+export default RecurringTimeslotForm;

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { EventImpl } from '@fullcalendar/core/internal';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { TimeslotEntry } from '@lentovaraukset/shared/src';
@@ -13,7 +13,9 @@ type RecurringTimeslotProps = {
 type Inputs = {
   start: string
   end: string
-  recurring: string
+  isRecurring: boolean
+  periodStarts: string | null
+  periodEnds: string | null
 };
 
 function RecurringTimeslotForm({
@@ -21,22 +23,26 @@ function RecurringTimeslotForm({
   onSubmit,
   id,
 }: RecurringTimeslotProps) {
+  const [showRecurring, setShowRecurring] = useState(false);
   const {
     register, handleSubmit, reset,
   } = useForm<Inputs>({
     values: {
       start: timeslot?.startStr.replace(/.{3}\+.*/, '') || '',
       end: timeslot?.endStr.replace(/.{3}\+.*/, '') || '',
-      recurring: 'Ei toistu',
+      isRecurring: false,
+      periodStarts: timeslot?.startStr.replace(/T.*/, '') || '',
+      periodEnds: timeslot?.endStr.replace(/T.*/, '') || '',
     },
   });
   const submitHandler: SubmitHandler<Inputs> = async (formData) => {
     const updatedTimeslot = {
       start: new Date(formData.start),
       end: new Date(formData.end),
-      recurring: formData.recurring,
+      isRecurring: formData.isRecurring,
+      periodStarts: formData.periodStarts,
+      periodEnds: formData.periodEnds,
     };
-
     onSubmit(updatedTimeslot);
   };
   const onError = (e: any) => console.error(e);
@@ -64,7 +70,6 @@ function RecurringTimeslotForm({
         {
           timeslot
           && (
-          /* eslint-disable  react/jsx-props-no-spreading */
           <form id={id} className="flex flex-col w-fit" onSubmit={handleSubmit(submitHandler, onError)}>
             <div className="flex flex-row space-x-6">
               <div className="flex flex-col">
@@ -82,17 +87,34 @@ function RecurringTimeslotForm({
                 />
               </div>
             </div>
-            <div className="flex flex-col">
-              <p>
-                Toistuvuus:
-              </p>
-              <select name="recurring-events">
-                <option value="none">Ei toistu</option>
-                <option value="weekdays">Arkipäivisin</option>
-              </select>
+            <InputField
+              labelText="Määritä toistuvuus"
+              type="checkbox"
+              onChange={() => {
+                console.log('moi');
+                setShowRecurring(!showRecurring);
+              }}
+              registerReturn={register('isRecurring')}
+            />
+            {showRecurring && (
+            <div className="flex flex-row space-x-6">
+              <div className="flex flex-col">
+                <InputField
+                  labelText="Alkaa:"
+                  type="date"
+                  registerReturn={register('periodStarts')}
+                />
+              </div>
+              <div className="flex flex-col">
+                <InputField
+                  labelText="Päättyy:"
+                  type="date"
+                  registerReturn={register('periodEnds')}
+                />
+              </div>
             </div>
+            )}
           </form>
-          /* eslint-enable  react/jsx-props-no-spreading */
           )
         }
       </div>

--- a/frontend/src/modals/TimeslotInfoModal.tsx
+++ b/frontend/src/modals/TimeslotInfoModal.tsx
@@ -1,0 +1,47 @@
+import { EventImpl } from '@fullcalendar/core/internal';
+import React from 'react';
+import Button from '../components/Button';
+import Card from '../components/Card';
+import RecurringTimeslotForm from '../components/forms/RecurringTimeslotForm';
+
+type InfoModalProps = {
+  showInfoModal: boolean
+  closeTimeslotModal: () => void
+  timeslot?: EventImpl
+  removeTimeslot: () => void
+};
+
+function TimeslotInfoModal({
+  showInfoModal,
+  closeTimeslotModal,
+  timeslot,
+  removeTimeslot,
+}: InfoModalProps) {
+  return (
+    <Card show={showInfoModal} handleClose={closeTimeslotModal}>
+      <RecurringTimeslotForm
+        id="recurring_timeslot_form"
+        timeslot={timeslot}
+        onSubmit={async (updatedTimeslot) => {
+          console.dir(updatedTimeslot);
+          closeTimeslotModal();
+        }}
+      />
+      <Button
+        variant="danger"
+        onClick={() => removeTimeslot()}
+      >
+        Poista
+      </Button>
+      <Button
+        form="recurring_timeslot_form"
+        type="submit"
+        variant="primary"
+      >
+        Tallenna
+      </Button>
+    </Card>
+  );
+}
+
+export default TimeslotInfoModal;

--- a/frontend/src/modals/TimeslotInfoModal.tsx
+++ b/frontend/src/modals/TimeslotInfoModal.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from '../components/Button';
 import Card from '../components/Card';
 import RecurringTimeslotForm from '../components/forms/RecurringTimeslotForm';
+import { modifyTimeSlot } from '../queries/timeSlots';
 
 type InfoModalProps = {
   showInfoModal: boolean
@@ -23,7 +24,13 @@ function TimeslotInfoModal({
         id="recurring_timeslot_form"
         timeslot={timeslot}
         onSubmit={async (updatedTimeslot) => {
-          console.dir(updatedTimeslot);
+          await modifyTimeSlot(
+            {
+              id: timeslot!.id,
+              start: updatedTimeslot.start,
+              end: updatedTimeslot.end,
+            },
+          );
           closeTimeslotModal();
         }}
       />

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -1,5 +1,6 @@
 import { EventRemoveArg, EventSourceFunc } from '@fullcalendar/core';
 import { EventImpl } from '@fullcalendar/core/internal';
+import FullCalendar from '@fullcalendar/react';
 import React, { useState, useRef } from 'react';
 import Calendar from '../components/Calendar';
 import TimeslotInfoModal from '../modals/TimeslotInfoModal';
@@ -15,6 +16,7 @@ function TimeSlotCalendar() {
   const { data: airfield } = useAirfield(1); // TODO: get id from airfield selection
   const [showInfoModal, setShowInfoModal] = useState(false);
   const selectedTimeslotRef = useRef<EventImpl | null>(null);
+  const calendarRef: React.RefObject<FullCalendar> = React.createRef();
 
   const timeSlotsSourceFn: EventSourceFunc = async (
     { start, end },
@@ -78,11 +80,13 @@ function TimeSlotCalendar() {
         closeTimeslotModal={() => {
           closeTimeslotModalFn();
           selectedTimeslotRef.current = null;
+          calendarRef.current?.getApi().refetchEvents();
         }}
       />
 
       <h1 className="text-3xl">Vapaat varausikkunat</h1>
       <Calendar
+        calendarRef={calendarRef}
         eventSources={eventsSourceRef.current}
         addEventFn={addTimeSlot}
         modifyEventFn={modifyTimeSlot}

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -50,6 +50,8 @@ function TimeSlotCalendar() {
     }
   };
 
+  const eventsSourceRef = useRef([reservationsSourceFn, timeSlotsSourceFn]);
+
   const clickTimeslot = async (event: EventImpl): Promise<void> => {
     selectedTimeslotRef.current = event;
     setShowInfoModal(true);
@@ -81,7 +83,7 @@ function TimeSlotCalendar() {
 
       <h1 className="text-3xl">Vapaat varausikkunat</h1>
       <Calendar
-        eventSources={[timeSlotsSourceFn, reservationsSourceFn]}
+        eventSources={eventsSourceRef.current}
         addEventFn={addTimeSlot}
         modifyEventFn={modifyTimeSlot}
         clickEventFn={clickTimeslot}


### PR DESCRIPTION
Related to Issue #217 

## What changes has been added?

### Backend
-
### Frontend
Clicking timeslot opens a modal where user can 
1) change start and end time of the event (connected to backend)
2) give a date range for recurring events (backend not yet implemented)
## Expected Behaviour
![Screenshot from 2023-03-10 11-06-47](https://user-images.githubusercontent.com/65664408/224273235-4a2dbfb7-ff28-45a5-9dd0-36efd06164fe.png)
![Screenshot from 2023-03-10 11-06-57](https://user-images.githubusercontent.com/65664408/224273254-9eb2eaf5-a2cf-46a4-8486-4dbc413baa3c.png)

