### PR TITLE
214 zod validointiin varmistus etteivät fieldit ole tyhjiä

### DIFF
--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -105,6 +105,27 @@ describe('Calls to api', () => {
     expect(createdReservation?.dataValues.phone).toEqual('11104040');
   });
 
+  test('cannot create a reservation with empty phone number', async () => {
+    const result: any = await api.post('/api/reservations/')
+      .set('Content-type', 'application/json')
+      .send({
+        start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: ' ',
+      });
+    console.log(result.body);
+    expect(result.statusCode).toEqual(400);
+    expect(result.body.error.message.includes('Phone number cannot be empty'));
+  });
+
+  test('cannot create a reservation with empty aircraft ID', async () => {
+    const result: any = await api.post('/api/reservations/')
+      .set('Content-type', 'application/json')
+      .send({
+        start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: ' ', info: 'Training flight', phone: '11104040',
+      });
+    expect(result.statusCode).toEqual(400);
+    expect(result.body.error.message.includes('Aircraft ID cannot be empty'));
+  });
+
   test('can delete a reservation', async () => {
     const createdReservation: Reservation | null = await Reservation.findOne();
     const id = createdReservation?.dataValues.id;
@@ -153,6 +174,40 @@ describe('Calls to api', () => {
     expect(updatedReservation?.dataValues.end).toEqual(new Date('2023-02-14T16:00:00.000Z'));
     expect(updatedReservation?.dataValues.aircraftId).toEqual(aircraftId);
     expect(updatedReservation?.dataValues.phone).toEqual(phone);
+  });
+
+  test('cannot modify a reservation to have an empty phone number', async () => {
+    const createdReservation: Reservation | null = await Reservation.findOne();
+    const id = createdReservation?.dataValues.id;
+
+    const updatedReservation: any = await api.put(`/api/reservations/${id}`)
+      .set('Content-type', 'application/json')
+      .send({
+        start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: ' ',
+      });
+
+    expect(updatedReservation.statusCode).toEqual(400);
+    expect(updatedReservation.body.error.message.includes('Phone number cannot be empty'));
+
+    const reservationAfterUpdate: Reservation | null = await Reservation.findByPk(id);
+    expect(reservationAfterUpdate?.dataValues.phone).not.toEqual('');
+  });
+
+  test('cannot modify a reservation to have an empty aircraft ID', async () => {
+    const createdReservation: Reservation | null = await Reservation.findOne();
+    const id = createdReservation?.dataValues.id;
+
+    const updatedReservation: any = await api.put(`/api/reservations/${id}`)
+      .set('Content-type', 'application/json')
+      .send({
+        start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: ' ', info: 'Training flight', phone: '11104040',
+      });
+
+    expect(updatedReservation.statusCode).toEqual(400);
+    expect(updatedReservation.body.error.message.includes('Aircraft ID cannot be empty'));
+
+    const reservationAfterUpdate: Reservation | null = await Reservation.findByPk(id);
+    expect(reservationAfterUpdate?.dataValues.aircraftId).not.toEqual('');
   });
 
   test('can get reservations in a range', async () => {

--- a/frontend/src/modals/ReservationInfoModal.tsx
+++ b/frontend/src/modals/ReservationInfoModal.tsx
@@ -1,8 +1,10 @@
 import { EventImpl } from '@fullcalendar/core/internal';
-import React from 'react';
+import { ReservationEntry } from '@lentovaraukset/shared/src';
+import React, { useContext } from 'react';
 import Button from '../components/Button';
 import Card from '../components/Card';
 import ReservationInfoForm from '../components/forms/ReservationInfoForm';
+import AlertContext from '../contexts/AlertContext';
 import { modifyReservation } from '../queries/reservations';
 
 type InfoModalProps = {
@@ -18,26 +20,30 @@ function ReservationInfoModal({
   reservation,
   removeReservation,
 }: InfoModalProps) {
+  const { addNewAlert } = useContext(AlertContext);
+  const handleSubmit = async (updatedReservation: Omit<ReservationEntry, 'id' | 'user'>) => {
+    const modifiedReservation = await modifyReservation(
+      {
+        id: parseInt(reservation!.id, 10),
+        start: updatedReservation.start,
+        end: updatedReservation.end,
+        user: 'NYI',
+        aircraftId: updatedReservation.aircraftId,
+        phone: updatedReservation.phone,
+        info: updatedReservation.info,
+      },
+    );
+    if (modifiedReservation) {
+      addNewAlert(`Varaus #${modifiedReservation.id} päivitetty!`, 'success');
+    }
+    closeReservationModal();
+  };
   return (
     <Card show={showInfoModal} handleClose={closeReservationModal}>
       <ReservationInfoForm
         id="reservation_info_form"
         reservation={reservation}
-        onSubmit={async (updatedReservation) => {
-          await modifyReservation(
-            {
-              id: parseInt(reservation!.id, 10),
-              start: updatedReservation.start,
-              end: updatedReservation.end,
-              user: 'NYI',
-              aircraftId: updatedReservation.aircraftId,
-              phone: updatedReservation.phone,
-              info: updatedReservation.info,
-            },
-          );
-
-          closeReservationModal();
-        }}
+        onSubmit={handleSubmit}
       />
       <Button
         variant="danger"

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -1,5 +1,5 @@
 import { EventRemoveArg, EventSourceFunc } from '@fullcalendar/core';
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useContext } from 'react';
 import { EventImpl } from '@fullcalendar/core/internal';
 import FullCalendar from '@fullcalendar/react';
 import Calendar from '../components/Calendar';
@@ -12,6 +12,7 @@ import {
 import { getTimeSlots } from '../queries/timeSlots';
 import ReservationInfoModal from '../modals/ReservationInfoModal';
 import useAirfield from '../queries/airfields';
+import AlertContext from '../contexts/AlertContext';
 
 function ReservationCalendar() {
   const [showInfoModal, setShowInfoModal] = useState(false);
@@ -19,7 +20,7 @@ function ReservationCalendar() {
   const calendarRef: React.RefObject<FullCalendar> = React.createRef();
 
   const { data: airfield } = useAirfield(1); // TODO: get id from airfield selection
-
+  const { addNewAlert } = useContext(AlertContext);
   const reservationsSourceFn: EventSourceFunc = async (
     { start, end },
     successCallback,
@@ -102,7 +103,7 @@ function ReservationCalendar() {
       user, aircraftId, phone, email, info,
     } = event.extendedProps;
 
-    await modifyReservation({
+    const modifiedReservation = await modifyReservation({
       id: parseInt(event.id, 10),
       start: event.start,
       end: event.end,
@@ -112,6 +113,9 @@ function ReservationCalendar() {
       email,
       info,
     });
+    if (modifiedReservation) {
+      addNewAlert('Reservation modified', 'success');
+    }
   };
 
   return (

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -40,8 +40,8 @@ const createReservationValidator = (slotGranularityMinutes: number, maxDaysInFut
   const pastErrorMessage = 'Reservation cannot be in past';
   const tooFarInFutureErrorMessage = `Reservation start time cannot be further than ${maxDaysInFuture} days away`;
   const startNotLessThanEndErrorMessage = 'Reservation start time cannot be later than the end time';
-  const aircraftIdEmptyErrorMessage = 'Koneen rekisteritunnus ei voi olla tyhjä';
-  const phoneNumberEmptyErrorMessage = 'Puhelinnumero ei voi olla tyhjä';
+  const aircraftIdEmptyErrorMessage = 'Aircraft ID cannot be empty';
+  const phoneNumberEmptyErrorMessage = 'Phone number cannot be empty';
 
   const Reservation = z.object({
     start: z.coerce

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -40,6 +40,8 @@ const createReservationValidator = (slotGranularityMinutes: number, maxDaysInFut
   const pastErrorMessage = 'Reservation cannot be in past';
   const tooFarInFutureErrorMessage = `Reservation start time cannot be further than ${maxDaysInFuture} days away`;
   const startNotLessThanEndErrorMessage = 'Reservation start time cannot be later than the end time';
+  const aircraftIdEmptyErrorMessage = 'Koneen rekisteritunnus ei voi olla tyhjä';
+  const phoneNumberEmptyErrorMessage = 'Puhelinnumero ei voi olla tyhjä';
 
   const Reservation = z.object({
     start: z.coerce
@@ -54,9 +56,9 @@ const createReservationValidator = (slotGranularityMinutes: number, maxDaysInFut
       .date()
       .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
       .refine((value) => !isTimeInPast(value), { message: pastErrorMessage }),
-    aircraftId: z.string(),
+    aircraftId: z.string().trim().min(1, { message: aircraftIdEmptyErrorMessage }),
     info: z.string().optional(),
-    phone: z.string(),
+    phone: z.string().trim().min(1, { message: phoneNumberEmptyErrorMessage }),
   })
     .refine((res) => res.start < res.end, { message: startNotLessThanEndErrorMessage });
 


### PR DESCRIPTION
Related to Issue #214 

## What changes has been added?
Zod validation that check reservation phone number and aircraft id are not empty 
### Backend

### Frontend

## Expected Behaviour
User can't create or modify reservation without giving phone number and aircraft id
