### PR TITLE
timeslot type can be chosen on calendar view

### DIFF
--- a/backend/__tests__/index.test.ts
+++ b/backend/__tests__/index.test.ts
@@ -46,7 +46,7 @@ describe('basic function tests', () => {
 
   test('Adding timeslot just to db works', async () => {
     const date = new Date();
-    await Timeslot.create({ start: date, end: date });
+    await Timeslot.create({ start: date, end: date, type: 'available' });
 
     // temporarily any. Models don't have types defined yet
     const slot: any = await Timeslot.findOne();

--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -56,6 +56,7 @@ beforeEach(async () => {
   await Timeslot.create({
     start: new Date('2023-02-12T08:00:00.000Z'),
     end: new Date('2023-02-15T08:00:00.000Z'),
+    type: 'available',
   });
 });
 

--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -128,6 +128,21 @@ describe('Calls to api', () => {
     expect(result.body.error.message.includes('Aircraft ID cannot be empty'));
   });
 
+  test('cannot create a reservation on top of blocked timeslot', async () => {
+    await Timeslot.create({
+      start: new Date('2023-02-12T08:00:00.000Z'),
+      end: new Date('2023-02-12T16:00:00.000Z'),
+      type: 'blocked',
+    });
+    const result: any = await api.post('/api/reservations/')
+      .set('Content-type', 'application/json')
+      .send({
+        start: new Date('2023-02-12T12:00:00.000Z'), end: new Date('2023-02-12T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: '11104040',
+      });
+    expect(result.statusCode).toEqual(400);
+    expect(result.body.error.message.includes('Reservation cannot be created on top of blocked timeslot'));
+  });
+
   test('can delete a reservation', async () => {
     const createdReservation: Reservation | null = await Reservation.findOne();
     const id = createdReservation?.dataValues.id;
@@ -193,6 +208,23 @@ describe('Calls to api', () => {
 
     const reservationAfterUpdate: Reservation | null = await Reservation.findByPk(id);
     expect(reservationAfterUpdate?.dataValues.phone).not.toEqual('');
+  });
+
+  test('cannot update a reservation on top of blocked timeslot', async () => {
+    const createdReservation: Reservation | null = await Reservation.findOne();
+    const id = createdReservation?.dataValues.id;
+    await Timeslot.create({
+      start: new Date('2023-02-12T08:00:00.000Z'),
+      end: new Date('2023-02-12T16:00:00.000Z'),
+      type: 'blocked',
+    });
+    const result: any = await api.put(`/api/reservations/${id}`)
+      .set('Content-type', 'application/json')
+      .send({
+        start: new Date('2023-02-12T12:00:00.000Z'), end: new Date('2023-02-12T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: '11104040',
+      });
+    expect(result.statusCode).toEqual(400);
+    expect(result.body.error.message.includes('Reservation cannot be created on top of blocked timeslot'));
   });
 
   test('cannot modify a reservation to have an empty aircraft ID', async () => {

--- a/backend/src/models/timeslot.ts
+++ b/backend/src/models/timeslot.ts
@@ -40,12 +40,12 @@ Timeslot.init(
     },
     start: {
       type: DataTypes.DATE,
-      unique: true,
+      unique: false,
       allowNull: false,
     },
     end: {
       type: DataTypes.DATE,
-      unique: true,
+      unique: false,
       allowNull: false,
     },
     type: {

--- a/backend/src/models/timeslot.ts
+++ b/backend/src/models/timeslot.ts
@@ -22,6 +22,8 @@ InferCreationAttributes<Timeslot>
 
   declare end: Date;
 
+  declare type: 'available' | 'blocked';
+
   declare addReservations: HasManyAddAssociationsMixin<Reservation, number>;
 
   declare getReservations: HasManyGetAssociationsMixin<Reservation>;
@@ -45,6 +47,19 @@ Timeslot.init(
       type: DataTypes.DATE,
       unique: true,
       allowNull: false,
+    },
+    type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'available',
+      validate: {
+        customValidator: (value: string) => {
+          const enums = ['available', 'blocked'];
+          if (!enums.includes(value)) {
+            throw new Error('not a valid option');
+          }
+        },
+      },
     },
   },
   {

--- a/backend/src/models/timeslot.ts
+++ b/backend/src/models/timeslot.ts
@@ -24,7 +24,7 @@ InferCreationAttributes<Timeslot>
 
   declare type: TimeslotType;
 
-  declare groupId: string | null;
+  declare group: string | null;
 
   declare addReservations: HasManyAddAssociationsMixin<Reservation, number>;
 
@@ -33,7 +33,7 @@ InferCreationAttributes<Timeslot>
   declare removeReservations: HasManyRemoveAssociationsMixin<Reservation, number>;
 
   static async addGroupTimeslots(
-    timeslots: { groupId:string, start: Date, end: Date, type: TimeslotType }[],
+    timeslots: { group:string, start: Date, end: Date, type: TimeslotType }[],
   ) {
     return sequelize.transaction(async (transaction) => Timeslot
       .bulkCreate(timeslots, { transaction }));
@@ -70,7 +70,7 @@ Timeslot.init(
         },
       },
     },
-    groupId: {
+    group: {
       type: DataTypes.STRING,
       allowNull: true,
       unique: false,

--- a/backend/src/services/reservationService.ts
+++ b/backend/src/services/reservationService.ts
@@ -32,6 +32,9 @@ const deleteById = async (id: number) => {
 const createReservation = async (newReservation: Omit<ReservationEntry, 'id' | 'user'>): Promise<ReservationEntry> => {
   const timeslots = await timeslotService
     .getInTimeRange(newReservation.start, newReservation.end);
+  if (timeslots.some((timeslot) => timeslot.type === 'blocked')) {
+    throw new Error('Reservation cannot be created on top of blocked timeslot');
+  }
   if (timeslots.length !== 1) {
     throw new Error('Reservation should be created for one timeslot');
   }
@@ -50,6 +53,9 @@ const updateById = async (
 ): Promise<ReservationEntry> => {
   const newTimeslots = await timeslotService
     .getInTimeRange(reservation.start, reservation.end);
+  if (newTimeslots.some((timeslot) => timeslot.type === 'blocked')) {
+    throw new Error('Reservation cannot be created on top of blocked timeslot');
+  }
   if (newTimeslots.length !== 1) {
     throw new Error('Reservation should be created for one timeslot');
   }

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -91,11 +91,11 @@ const createPeriod = async (
   }
   const firstTimeslot: Timeslot | null = await Timeslot.findByPk(id);
   if (firstTimeslot) {
-    firstTimeslot.groupId = period.name;
+    firstTimeslot.group = period.name;
     await firstTimeslot.save();
   }
   const addedTimeslot = await Timeslot
-    .addGroupTimeslots(timeslotGroup.map((t) => ({ ...t, groupId: period.name })));
+    .addGroupTimeslots(timeslotGroup.map((t) => ({ ...t, group: period.name })));
   return addedTimeslot;
 };
 

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -63,7 +63,7 @@ const deleteById = async (id: number) => {
 
 const updateById = async (
   id: number,
-  timeslot: { start: Date, end: Date },
+  timeslot: { start: Date, end: Date, type: 'available' | 'blocked' },
 ): Promise<void> => {
   if (await timeslotsAreConsecutive(timeslot, id)) {
     throw new Error('Timeslot can\'t be consecutive');
@@ -85,6 +85,7 @@ const updateById = async (
 const createTimeslot = async (newTimeSlot: {
   start: Date;
   end: Date;
+  type: 'available' | 'blocked';
 }): Promise<TimeslotEntry> => {
   if (await timeslotsAreConsecutive(newTimeSlot)) {
     throw new Error('Timeslot can\'t be consecutive');

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import type { TimeslotEntry } from '@lentovaraukset/shared/src/index';
+import type { TimeslotEntry, TimeslotType } from '@lentovaraukset/shared/src/index';
 import reservationService from '@lentovaraukset/backend/src/services/reservationService';
 import { isTimeInPast } from '@lentovaraukset/shared/src/validation/validation';
 import { Timeslot } from '../models';
@@ -34,7 +34,7 @@ const getInTimeRange = async (
 };
 
 const timeslotsAreConsecutive = async (
-  timeslot: { start: Date, end: Date, type: 'available' | 'blocked' },
+  timeslot: { start: Date, end: Date, type: TimeslotType },
   id: number | null = null,
 ): Promise<boolean> => {
   const { start, end, type } = timeslot;
@@ -63,7 +63,7 @@ const deleteById = async (id: number) => {
 
 const updateById = async (
   id: number,
-  timeslot: { start: Date, end: Date, type: 'available' | 'blocked' },
+  timeslot: { start: Date, end: Date, type: TimeslotType },
 ): Promise<void> => {
   if (await timeslotsAreConsecutive(timeslot, id)) {
     throw new Error('Timeslot can\'t be consecutive');
@@ -89,7 +89,7 @@ const updateById = async (
 const createTimeslot = async (newTimeSlot: {
   start: Date;
   end: Date;
-  type: 'available' | 'blocked';
+  type: TimeslotType;
 }): Promise<TimeslotEntry> => {
   if (await timeslotsAreConsecutive(newTimeSlot)) {
     throw new Error('Timeslot can\'t be consecutive');

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -127,7 +127,7 @@ function Calendar({
     calendarRef.current?.getApi().unselect();
   };
 
-  const handleAllow: AllowFunc = (s, m) => allowEvent(s, m) && allowEventRef(s, m);
+  const handleAllow: AllowFunc = (s, m) => allowEventRef(s, m) ?? allowEvent(s, m);
 
   return (
     <FullCalendar

--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -6,8 +6,10 @@ export interface FieldProps {
   state?: InputStates;
   type: React.InputHTMLAttributes<HTMLInputElement>['type']
 
-  value: React.InputHTMLAttributes<HTMLInputElement>['value']
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  value?: React.InputHTMLAttributes<HTMLInputElement>['value'];
+  name?: React.InputHTMLAttributes<HTMLInputElement>['name'];
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
 
   placeholder?: string;
 
@@ -24,10 +26,12 @@ export interface FieldProps {
   defaultValue?: string;
 }
 
-export interface RHFFieldProps extends Omit<FieldProps, 'registerReturn' | 'value' | 'onChange'> {
-  // these are optional with RHF
-  value?: React.InputHTMLAttributes<HTMLInputElement>['value']
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+export interface RHFFieldProps extends Omit<FieldProps, 'registerReturn' | 'value' | 'onChange' | 'onBlur'> {
+  // RHF's register provides these
+  value?: undefined;
+  onChange?: undefined;
+  name?: undefined;
+  onBlur?: undefined;
 
   // React Hook Form register return value
   registerReturn: UseFormRegisterReturn<any>;
@@ -35,7 +39,8 @@ export interface RHFFieldProps extends Omit<FieldProps, 'registerReturn' | 'valu
 
 function InputField({
   state = 'default',
-  type, value, onChange,
+  type,
+  value, name, onChange, onBlur,
   placeholder, labelText, helperText,
   registerReturn,
   labelClassName = '',
@@ -68,6 +73,9 @@ function InputField({
         id={id}
         type={type}
         value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        name={name}
         disabled={state === 'disabled'}
         placeholder={placeholder}
         className={`${fieldBaseClass} ${fieldStateClasses[state]} ${inputClassName}`}
@@ -77,7 +85,6 @@ function InputField({
         // are complicated to do
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...registerReturn}
-        onChange={onChange}
       />
       {helperText ? <p className={`text-ft-text-300 -mt-4 ${helperTextClassName}`}>{helperText}</p> : null}
     </div>

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { EventImpl } from '@fullcalendar/core/internal';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { TimeslotEntry } from '@lentovaraukset/shared/src';
@@ -24,9 +24,8 @@ function RecurringTimeslotForm({
   onSubmit,
   id,
 }: RecurringTimeslotProps) {
-  const [showRecurring, setShowRecurring] = useState(false);
   const {
-    register, handleSubmit, reset,
+    register, handleSubmit, reset, watch,
   } = useForm<Inputs>({
     values: {
       start: timeslot?.startStr.replace(/.{3}\+.*/, '') || '',
@@ -52,6 +51,8 @@ function RecurringTimeslotForm({
   useEffect(() => {
     reset();
   }, [timeslot]);
+
+  const showRecurring = watch('isRecurring');
 
   return (
     <div>
@@ -83,7 +84,6 @@ function RecurringTimeslotForm({
                 <InputField
                   labelText="Määritä toistuvuus"
                   type="checkbox"
-                  onChange={() => setShowRecurring(!showRecurring)}
                   registerReturn={register('isRecurring')}
                 />
                 {showRecurring && (

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -13,6 +13,7 @@ type RecurringTimeslotProps = {
 type Inputs = {
   start: string
   end: string
+  type: 'available' | 'blocked'
   isRecurring: boolean
   periodStarts: string | null
   periodEnds: string | null
@@ -30,6 +31,7 @@ function RecurringTimeslotForm({
     values: {
       start: timeslot?.startStr.replace(/.{3}\+.*/, '') || '',
       end: timeslot?.endStr.replace(/.{3}\+.*/, '') || '',
+      type: 'available',
       isRecurring: false,
       periodStarts: timeslot?.startStr.replace(/T.*/, '') || '',
       periodEnds: timeslot?.endStr.replace(/T.*/, '') || '',
@@ -39,6 +41,7 @@ function RecurringTimeslotForm({
     const updatedTimeslot = {
       start: new Date(formData.start),
       end: new Date(formData.end),
+      type: formData.type,
     };
     // TODO: create recurring events if possible
     // const { isRecurring, periodStarts, periodEnds } = formData;

--- a/frontend/src/modals/TimeslotInfoModal.tsx
+++ b/frontend/src/modals/TimeslotInfoModal.tsx
@@ -26,9 +26,10 @@ function TimeslotInfoModal({
         onSubmit={async (updatedTimeslot) => {
           await modifyTimeSlot(
             {
-              id: timeslot!.id,
+              id: Number(timeslot!.id),
               start: updatedTimeslot.start,
               end: updatedTimeslot.end,
+              type: updatedTimeslot.type,
             },
           );
           closeTimeslotModal();

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -29,16 +29,14 @@ function TimeSlotCalendar() {
     try {
       const timeslots = await getTimeSlots(start, end);
       const timeslotsMapped = timeslots.map((timeslot) => {
-        const color = timeslot.type === 'available' ? '#84cc1680' : '#eec200';
-        const title = timeslot.type === 'available' ? 'Vapaa' : 'Suljettu';
-        return {
+        const timeslotEvent = {
           ...timeslot,
           id: timeslot.id.toString(),
-          color,
-          title,
+          color: timeslot.type === 'available' ? '#84cc1680' : '#eec200',
+          title: timeslot.type === 'available' ? 'Vapaa' : 'Suljettu',
           editable: !isTimeInPast(timeslot.start),
-          groupId: timeslot.groupId ?? undefined,
         };
+        return timeslot.group ? { ...timeslotEvent, groupId: timeslot.group } : timeslotEvent;
       });
       successCallback(timeslotsMapped);
     } catch (error) {

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -37,6 +37,7 @@ function TimeSlotCalendar() {
           color,
           title,
           editable: !isTimeInPast(timeslot.start),
+          groupId: timeslot.groupId ?? undefined,
         };
       });
       successCallback(timeslotsMapped);

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -98,15 +98,28 @@ function TimeSlotCalendar() {
   const allowEvent: AllowFunc = (span, movingEvent) => {
     const timeIsConsecutive = calendarRef.current?.getApi().getEvents().some(
       (e) => e.id !== movingEvent?.id
-        && e.groupId !== 'reservations'
-        && e.start && e.end
+      && e.groupId !== 'reservations'
+      && (
+        (e.extendedProps.type === 'available' && !blocked)
+        || (e.extendedProps.type === 'blocked' && blocked)
+      )
+      && e.start && e.end
         && (e.start.getTime() === span.start.getTime()
           || e.start.getTime() === span.end.getTime()
           || e.end.getTime() === span.start.getTime()
           || e.end.getTime() === span.end.getTime()),
     );
-
-    return !timeIsConsecutive;
+    const overlap = calendarRef.current?.getApi().getEvents().some(
+      (e) => e.id !== movingEvent?.id
+        && e.start && e.end
+        && (
+          (e.extendedProps.type === 'available' && !blocked)
+          || (e.extendedProps.type === 'blocked' && blocked)
+        )
+        && !e.display.includes('background')
+        && e.start < span.end && e.end > span.start,
+    );
+    return !timeIsConsecutive && !overlap;
   };
 
   const handleToggle = () => {

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -63,6 +63,16 @@ function TimeSlotCalendar() {
     setShowInfoModal(false);
   };
 
+  const addTimeslotFn = async (event: { start: Date, end: Date }) => {
+    await addTimeSlot({ ...event, type: 'available' });
+  };
+
+  const modifyTimeslotFn = async (event: { id: string, start: Date, end: Date }) => {
+    await modifyTimeSlot({
+      ...event, id: Number(event.id), type: 'available',
+    });
+  };
+
   const removeTimeSlot = async (removeInfo: EventRemoveArg) => {
     const { event } = removeInfo;
     await deleteTimeslot(Number(event.id));
@@ -102,8 +112,8 @@ function TimeSlotCalendar() {
       <Calendar
         calendarRef={calendarRef}
         eventSources={eventsSourceRef.current}
-        addEventFn={addTimeSlot}
-        modifyEventFn={modifyTimeSlot}
+        addEventFn={addTimeslotFn}
+        modifyEventFn={modifyTimeslotFn}
         clickEventFn={clickTimeslot}
         removeEventFn={removeTimeSlot}
         granularity={airfield && { minutes: airfield.eventGranularityMinutes }}

--- a/frontend/src/queries/timeSlots.ts
+++ b/frontend/src/queries/timeSlots.ts
@@ -1,11 +1,12 @@
 import { EventInput } from '@fullcalendar/core';
+import { TimeslotEntry } from '@lentovaraukset/shared/src';
 
 const getTimeSlots = async (from: Date, until: Date): Promise<EventInput[]> => {
   const res = await fetch(`${process.env.BASE_PATH}/api/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
   return res.json();
 };
 
-const addTimeSlot = async (newTimeSlot: { start: Date, end: Date }): Promise<void> => {
+const addTimeSlot = async (newTimeSlot: { start: Date, end: Date, type: 'available' | 'blocked' }): Promise<void> => {
   await fetch(`${process.env.BASE_PATH}/api/timeslots/`, {
     method: 'POST',
     headers: {
@@ -16,16 +17,11 @@ const addTimeSlot = async (newTimeSlot: { start: Date, end: Date }): Promise<voi
 };
 
 const modifyTimeSlot = async (
-  timeSlot: { id: string, start: Date, end: Date },
+  timeSlot: TimeslotEntry,
 ): Promise<void> => {
-  const modifiedTimeSlot = {
-    start: timeSlot.start,
-    end: timeSlot.end,
-  };
-
-  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/${timeSlot.id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/${String(timeSlot.id)}`, {
     method: 'PUT',
-    body: JSON.stringify(modifiedTimeSlot),
+    body: JSON.stringify(timeSlot),
     headers: {
       'Content-Type': 'application/json',
     },

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -13,6 +13,7 @@ export interface TimeslotEntry {
   id: number;
   start: Date;
   end: Date;
+  type: 'available' | 'blocked'
 }
 
 export interface AirfieldEntry {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -9,11 +9,13 @@ export interface ReservationEntry {
   info?: string;
 }
 
+export type TimeslotType = 'available' | 'blocked';
+
 export interface TimeslotEntry {
   id: number;
   start: Date;
   end: Date;
-  type: 'available' | 'blocked'
+  type: TimeslotType;
 }
 
 export interface AirfieldEntry {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -16,6 +16,7 @@ export interface TimeslotEntry {
   start: Date;
   end: Date;
   type: TimeslotType;
+  groupId?: string | null;
 }
 
 export interface AirfieldEntry {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -16,7 +16,7 @@ export interface TimeslotEntry {
   start: Date;
   end: Date;
   type: TimeslotType;
-  groupId?: string | null;
+  group?: string | null;
 }
 
 export interface AirfieldEntry {

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -29,6 +29,7 @@ const createTimeSlotValidator = (slotGranularityMinutes: number) => {
       .date()
       .refine(isMultipleOfMinutes(slotGranularityMinutes), { message })
       .refine((value) => !isTimeInPast(value), { message: pastErrorMessage }),
+    type: z.enum(['available', 'blocked']),
   })
     .refine((res) => res.start < res.end, { message: startNotLessThanEndErrorMessage });
 


### PR DESCRIPTION
Related to Issue #227 

## What changes has been added?

### Backend
Added type field for Timeslot Model. `timeslotsAreConsecutive` checks only slots of same type. Blocked timeslots are not connected to any reservations, logic for available timeslots is unchanged.

### Frontend
In Timeslot calendar, user can opt to add blocked or available timeslots on top of calendar view. Available timeslots have same constraints as before (they cannot be consecutive or overlap), and same constraints apply for blocked timeslots as well. 

In Reservation calendar, blocked timeslots are shown as light grey background event and user cannot create or modify reservations on top of them.

## Expected Behaviour
If checkbox on top of calendar is clicked, newly added events have `blocked` type. If it is not, they have `available` type. Both event types can be modified same as before.
![Screenshot from 2023-03-16 15-06-49](https://user-images.githubusercontent.com/65664408/225626212-ce938f43-f1e3-4dbb-843e-2575c85bfb6e.png)
