### PR TITLE
249 edit repeating timeslots

### DIFF
--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -57,7 +57,6 @@ router.put('/:id', async (req: express.Request, res: express.Response, next: exp
     const airfield = await airfieldService.getAirfield('EGLL'); // TODO: get airfieldId from request
     const modifiedTimeslot = createTimeSlotValidator(airfield.eventGranularityMinutes, true)
       .parse(req.body);
-    // TODO: check if timeslot overlaps with existing timeslots
 
     const id = Number(req.params.id);
     if (req.body.periodEnd) {
@@ -75,7 +74,7 @@ router.put('/:id', async (req: express.Request, res: express.Response, next: exp
 
 router.put('/group/:group', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   try {
-    const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
+    const airfield = await airfieldService.getAirfield('EGLL'); // TODO: get airfieldId from request
     const { group } = req.params;
     const updatedTimes = createGroupUpdateValidator(airfield.eventGranularityMinutes)
       .parse(req.body);

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -1,5 +1,10 @@
 import express from 'express';
-import { createTimeSlotValidator, getTimeRangeValidator, createPeriodValidation } from '@lentovaraukset/shared/src/validation/validation';
+import {
+  createTimeSlotValidator,
+  getTimeRangeValidator,
+  createPeriodValidation,
+  createGroupUpdateValidator,
+} from '@lentovaraukset/shared/src/validation/validation';
 import timeslotService from '../services/timeslotService';
 import airfieldService from '../services/airfieldService';
 
@@ -63,6 +68,19 @@ router.put('/:id', async (req: express.Request, res: express.Response, next: exp
       await timeslotService.updateById(id, modifiedTimeslot);
       res.status(200).json(modifiedTimeslot);
     }
+  } catch (error: unknown) {
+    next(error);
+  }
+});
+
+router.put('/group/:group', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  try {
+    const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
+    const { group } = req.params;
+    const updatedTimes = createGroupUpdateValidator(airfield.eventGranularityMinutes)
+      .parse(req.body);
+    const updatedTimeslots = await timeslotService.updateByGroup(group, updatedTimes);
+    res.json(updatedTimeslots);
   } catch (error: unknown) {
     next(error);
   }

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -80,7 +80,7 @@ const errorIfLeadsToConsecutivesOrOverlaps = async (
     });
   });
 
-  if (timeslotsInRanges.length > 0) {
+  if (timeslotsInRanges.filter((ts) => ts.type === timeslots[0].type).length > 0) {
     throw new Error('Operation would result in ovarlapping timeslots');
   }
 };

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -74,7 +74,7 @@ const createPeriod = async (
   const dayInMillis = 24 * 60 * 60 * 1000;
   const weekdays = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
 
-  const timeslotGroup: { start: Date, end: Date, type: TimeslotType, info: string | null }[] = [];
+  const timeslotGroup: Omit<TimeslotEntry, 'id'>[] = [];
   const {
     start,
     end,
@@ -93,6 +93,7 @@ const createPeriod = async (
         end: endTime,
         type,
         info,
+        group: period.name,
       });
     }
     currentDate.setTime(currentDate.getTime() + dayInMillis);
@@ -184,10 +185,14 @@ const createTimeslot = async (newTimeSlot: {
 };
 
 const updateByGroup = async (group: string, updates: {
+  startingFrom: Date;
   startTimeOfDay: { hours: number, minutes: number };
   endTimeOfDay: { hours: number, minutes: number };
 }): Promise<TimeslotEntry[]> => {
-  const timeslots = await Timeslot.findAll({ where: { group } });
+  const timeslots = await Timeslot.findAll({
+    where: { group, start: { [Op.gte]: updates.startingFrom } },
+  });
+
   const editedTimeslots = timeslots.map(({ dataValues: timeslot }) => {
     timeslot.start.setHours(updates.startTimeOfDay.hours, updates.startTimeOfDay.minutes);
     timeslot.end.setHours(updates.endTimeOfDay.hours, updates.endTimeOfDay.minutes);

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -4,50 +4,85 @@ import reservationService from '@lentovaraukset/backend/src/services/reservation
 import { isTimeInPast } from '@lentovaraukset/shared/src/validation/validation';
 import { Timeslot } from '../models';
 
-const getInTimeRange = async (
-  rangeStartTime: Date,
-  rangeEndTime: Date,
-  id: number | null = null,
+const getInTimeRanges = async (
+  ranges: {
+    rangeStartTime: Date,
+    rangeEndTime: Date,
+    id: number | null,
+  }[],
 ): Promise<Timeslot[]> => {
   const timeslots: Timeslot[] = await Timeslot.findAll({
     where: {
-      [Op.and]: [
-        {
-          start: {
-            [Op.lt]: rangeEndTime,
-          },
-          end: {
-            [Op.gt]: rangeStartTime,
-          },
-        },
-        id
-          ? {
-            id: {
-              [Op.ne]: id,
+      [Op.or]: ranges.map((range) => ({
+        [Op.and]: [
+          {
+            start: {
+              [Op.lt]: range.rangeEndTime,
             },
-          }
-          : {},
-      ],
+            end: {
+              [Op.gt]: range.rangeStartTime,
+            },
+          },
+          range.id
+            ? {
+              id: {
+                [Op.ne]: range.id,
+              },
+            }
+            : {},
+        ],
+      })),
     },
   });
   return timeslots;
 };
 
-const timeslotsAreConsecutive = async (
-  timeslot: { start: Date, end: Date, type: TimeslotType },
+const getInTimeRange = async (
+  rangeStartTime: Date,
+  rangeEndTime: Date,
   id: number | null = null,
-): Promise<boolean> => {
-  const { start, end, type } = timeslot;
-  const newStart = new Date(start);
-  const newEnd = new Date(end);
-  newStart.setMinutes(newStart.getMinutes() - 1);
-  newEnd.setMinutes(newEnd.getMinutes() + 1);
-  if (id) {
-    const consecutiveTimeslots = await getInTimeRange(newStart, newEnd, id);
-    return consecutiveTimeslots.filter((t) => t.type === type).length > 0;
+): Promise<Timeslot[]> => {
+  const timeslots: Timeslot[] = await getInTimeRanges([{
+    rangeStartTime,
+    rangeEndTime,
+    id,
+  }]);
+  return timeslots;
+};
+
+type TimeslotEntryOptionalId = Partial<TimeslotEntry> & Omit<TimeslotEntry, 'id'>;
+const errorIfLeadsToConsecutivesOrOverlaps = async (
+  timeslots: TimeslotEntryOptionalId[],
+): Promise<void> => {
+  const timeslotsInRanges = await getInTimeRanges(
+    timeslots.map((t) => {
+      const newStart = new Date(t.start);
+      const newEnd = new Date(t.end);
+      newStart.setMinutes(newStart.getMinutes() - 1);
+      newEnd.setMinutes(newEnd.getMinutes() + 1);
+      return {
+        rangeStartTime: newStart,
+        rangeEndTime: newEnd,
+        id: t.id ?? null,
+      };
+    }),
+  );
+
+  timeslots.forEach((timeslot) => {
+    timeslotsInRanges.forEach((otherTimeslot) => {
+      if (
+        timeslot.type === otherTimeslot.type
+        && (timeslot.start === otherTimeslot.end
+        || timeslot.end === otherTimeslot.start)
+      ) {
+        throw new Error('Operation would result in consecutive timeslots');
+      }
+    });
+  });
+
+  if (timeslotsInRanges.length > 0) {
+    throw new Error('Operation would result in ovarlapping timeslots');
   }
-  const consecutiveTimeslots = await getInTimeRange(newStart, newEnd);
-  return consecutiveTimeslots.filter((t) => t.type === type).length > 0;
 };
 
 const deleteById = async (id: number) => {
@@ -99,18 +134,8 @@ const createPeriod = async (
     currentDate.setTime(currentDate.getTime() + dayInMillis);
   }
 
-  const consecutivesFound = await Promise.all(
-    timeslotGroup.map((ts) => timeslotsAreConsecutive(ts)),
-  );
-  if (consecutivesFound.some((found) => found)) {
-    throw new Error("Timeslot can't be consecutive with another");
-  }
-  const overlaps = await Promise.all(
-    timeslotGroup.map((ts) => getInTimeRange(ts.start, ts.end)),
-  );
-  if (overlaps.some((foundSlots) => foundSlots.length > 0)) {
-    throw new Error('Period already has a timeslot');
-  }
+  await errorIfLeadsToConsecutivesOrOverlaps(timeslotGroup);
+
   const firstTimeslot: Timeslot | null = await Timeslot.findByPk(id);
   if (firstTimeslot) {
     firstTimeslot.group = period.name;
@@ -125,10 +150,8 @@ const updateById = async (
   id: number,
   timeslot: { start: Date, end: Date, type: TimeslotType, info: string | null },
 ): Promise<void> => {
-  if (await timeslotsAreConsecutive(timeslot, id)) {
-    throw new Error('Timeslot can\'t be consecutive');
-  }
   const oldTimeslot: Timeslot | null = await Timeslot.findByPk(id);
+  await errorIfLeadsToConsecutivesOrOverlaps([{ ...timeslot, id }]);
 
   if (oldTimeslot === null) {
     throw new Error('No timeslot with id exists');
@@ -172,9 +195,8 @@ const createTimeslot = async (newTimeSlot: {
   type: TimeslotType;
   info: string | null;
 }): Promise<TimeslotEntry> => {
-  if (await timeslotsAreConsecutive(newTimeSlot)) {
-    throw new Error('Timeslot can\'t be consecutive');
-  }
+  await errorIfLeadsToConsecutivesOrOverlaps([newTimeSlot]);
+
   const timeslot: Timeslot = await Timeslot.create(newTimeSlot);
   if (newTimeSlot.type === 'available') {
     const reservations = await reservationService
@@ -198,6 +220,8 @@ const updateByGroup = async (group: string, updates: {
     timeslot.end.setHours(updates.endTimeOfDay.hours, updates.endTimeOfDay.minutes);
     return timeslot;
   });
+
+  await errorIfLeadsToConsecutivesOrOverlaps(editedTimeslots);
 
   const updatedTimeslots = await Timeslot.bulkCreate(editedTimeslots, { updateOnDuplicate: ['start', 'end'] });
   return updatedTimeslots.map((ts) => ts.dataValues);

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -183,10 +183,26 @@ const createTimeslot = async (newTimeSlot: {
   return timeslot.dataValues;
 };
 
+const updateByGroup = async (group: string, updates: {
+  startTimeOfDay: { hours: number, minutes: number };
+  endTimeOfDay: { hours: number, minutes: number };
+}): Promise<TimeslotEntry[]> => {
+  const timeslots = await Timeslot.findAll({ where: { group } });
+  const editedTimeslots = timeslots.map(({ dataValues: timeslot }) => {
+    timeslot.start.setHours(updates.startTimeOfDay.hours, updates.startTimeOfDay.minutes);
+    timeslot.end.setHours(updates.endTimeOfDay.hours, updates.endTimeOfDay.minutes);
+    return timeslot;
+  });
+
+  const updatedTimeslots = await Timeslot.bulkCreate(editedTimeslots, { updateOnDuplicate: ['start', 'end'] });
+  return updatedTimeslots.map((ts) => ts.dataValues);
+};
+
 export default {
   getInTimeRange,
   deleteById,
   updateById,
   createTimeslot,
   createPeriod,
+  updateByGroup,
 };

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -189,7 +189,7 @@ function TimeSlotCalendar() {
     if (timeslot.extendedProps.group) {
       showPopup({
         popupTitle: 'Toistuvan varausikkunan muokkaus',
-        popupText: 'Muokkasit toistuvaa varausikkuuna. Muokataanko myös kaikkia tulevia varausikkunoita?',
+        popupText: `Muokkasit toistuvaa varausikkuuna. Muokataanko myös kaikkia tulevia ryhmän '${timeslot.extendedProps.group}' varausikkunoita?`,
         primaryText: 'Muokkaa kaikkia',
         primaryOnClick: modifyAllFutureEvents,
         secondaryText: 'Muokkaa vain tätä',

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -140,12 +140,6 @@ function TimeSlotCalendar() {
       days: WeekInDays,
     },
   ) => {
-    if (timeslot.extendedProps.type === 'blocked') {
-      selectedTimeslotRef.current = timeslot;
-      setShowInfoModal(true);
-      return;
-    }
-
     const start = timeslot.start ?? new Date();
     const end = timeslot.end ?? new Date();
     const modifyOneEvent = async () => {

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -14,7 +14,7 @@ import {
   getReservations,
 } from '../queries/reservations';
 import {
-  getTimeSlots, modifyTimeSlot, deleteTimeslot,
+  getTimeSlots, modifyTimeSlot, deleteTimeslot, modifyGroup,
 } from '../queries/timeSlots';
 import { usePopupContext } from '../contexts/PopupContext';
 
@@ -137,9 +137,19 @@ function TimeSlotCalendar() {
       id: string,
       start: Date,
       end: Date,
-      extendedProps: { type: TimeslotType, info: string | null },
+      extendedProps: { type: TimeslotType, info: string | null, group: string | null },
     },
   ) => {
+    if (event.extendedProps.group) {
+      // eslint-disable-next-line no-restricted-globals, no-alert
+      if (confirm('Muokaat toistuvaa varausikkunaa. Muokataanko kaikkia varausikkunoita?')) {
+        await modifyGroup(event.extendedProps.group, {
+          startTimeOfDay: { hours: event.start.getHours(), minutes: event.start.getMinutes() },
+          endTimeOfDay: { hours: event.end.getHours(), minutes: event.end.getMinutes() },
+        });
+        return;
+      }
+    }
     await modifyTimeSlot({
       ...event,
       id: Number(event.id),

--- a/frontend/src/queries/timeSlots.ts
+++ b/frontend/src/queries/timeSlots.ts
@@ -55,6 +55,7 @@ const deleteTimeslot = async (id: Number): Promise<string> => {
 };
 
 const modifyGroup = async (group: string, updates: {
+  startingFrom: Date,
   startTimeOfDay: { hours: number, minutes: number },
   endTimeOfDay: { hours: number, minutes: number }
 }): Promise<void> => {

--- a/frontend/src/queries/timeSlots.ts
+++ b/frontend/src/queries/timeSlots.ts
@@ -54,6 +54,20 @@ const deleteTimeslot = async (id: Number): Promise<string> => {
   return res.text();
 };
 
+const modifyGroup = async (group: string, updates: {
+  startTimeOfDay: { hours: number, minutes: number },
+  endTimeOfDay: { hours: number, minutes: number }
+}): Promise<void> => {
+  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/group/${group}`, {
+    method: 'PUT',
+    body: JSON.stringify(updates),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  errorIfNotOk(res);
+};
+
 export {
-  getTimeSlots, addTimeSlot, modifyTimeSlot, deleteTimeslot,
+  getTimeSlots, addTimeSlot, modifyTimeSlot, deleteTimeslot, modifyGroup,
 };

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -140,6 +140,7 @@ const createTimeOfDayValidator = (slotGranularityMinutes: number) => z.object({
 
 const createGroupUpdateValidator = (slotGranularityMinutes: number) => {
   const times = z.object({
+    startingFrom: z.coerce.date(),
     startTimeOfDay: createTimeOfDayValidator(slotGranularityMinutes),
     endTimeOfDay: createTimeOfDayValidator(slotGranularityMinutes),
   });

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -132,7 +132,23 @@ const airfieldValidator = () => {
   return base;
 };
 
+const createTimeOfDayValidator = (slotGranularityMinutes: number) => z.object({
+  hours: z.coerce.number().min(0).max(23),
+  minutes: z.coerce.number().min(0).max(59)
+    .refine((value) => value % slotGranularityMinutes === 0),
+});
+
+const createGroupUpdateValidator = (slotGranularityMinutes: number) => {
+  const times = z.object({
+    startTimeOfDay: createTimeOfDayValidator(slotGranularityMinutes),
+    endTimeOfDay: createTimeOfDayValidator(slotGranularityMinutes),
+  });
+
+  return times;
+};
+
 export {
+  createGroupUpdateValidator,
   createTimeSlotValidator,
   createReservationValidator,
   reservationIsWithinTimeslot,


### PR DESCRIPTION
Related to Issue #

## What changes has been added?

### Backend
API route and functionality to edit timeslots by group name

### Frontend
Popup to ask if the user wants to edit an individual timeslot or all future timeslots when editin a recurring timeslot

## Expected Behaviour
![image](https://user-images.githubusercontent.com/90393399/228469617-19c4bf3f-8fec-47ba-ab9c-0c35dfba33df.png)
Popup when editing recurring timeslot.

**Note**
Currently the group name is given by the user when creating the recurring event. This feature does not work if the user leaves the field empty.
