### PR TITLE
#277 fix not being able to edit a timeslot that is in progress

### DIFF
--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -166,6 +166,57 @@ describe('Calls to api', () => {
     expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-17T14:00:00.000Z'));
   });
 
+  test('can edit an available timeslot even if start time is in past', async () => {
+    const createdSlot: Timeslot = await Timeslot.create({
+      start: new Date('2023-02-13T07:00:00.000Z'),
+      end: new Date('2023-02-13T16:00:00.000Z'),
+      type: 'available',
+      info: null,
+    });
+
+    const res = await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+      .set('Content-type', 'application/json')
+      .send({
+        ...createdSlot.dataValues, end: '2023-02-13T20:00:00.000Z',
+      });
+
+    expect(res.body).toMatchObject({
+      end: '2023-02-13T20:00:00.000Z', info: null, start: '2023-02-13T07:00:00.000Z', type: 'available',
+    });
+    const updatedSlot: Timeslot | null = await Timeslot.findOne(
+      { where: { id: createdSlot.dataValues.id } },
+    );
+
+    expect(updatedSlot).toBeDefined();
+    expect(updatedSlot?.dataValues.start).toEqual(new Date('2023-02-13T07:00:00.000Z'));
+    expect(updatedSlot?.dataValues.end).toEqual(new Date('2023-02-13T20:00:00.000Z'));
+  });
+
+  test("cannot edit an available timeslot's start time if original is in past", async () => {
+    const createdSlot: Timeslot = await Timeslot.create({
+      start: new Date('2023-02-13T07:00:00.000Z'),
+      end: new Date('2023-02-13T16:00:00.000Z'),
+      type: 'available',
+      info: null,
+    });
+
+    const res = await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+      .set('Content-type', 'application/json')
+      .send({
+        ...createdSlot.dataValues, start: '2023-02-13T09:00:00.000Z',
+      });
+
+    expect(res.body.error.message).toContain('Timeslot in past cannot be modified');
+
+    const updatedSlot: Timeslot | null = await Timeslot.findOne(
+      { where: { id: createdSlot.dataValues.id } },
+    );
+
+    expect(updatedSlot).toBeDefined();
+    expect(updatedSlot?.dataValues.start).toEqual(createdSlot.start);
+    expect(updatedSlot?.dataValues.end).toEqual(createdSlot.end);
+  });
+
   test('can edit a blocked timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z'), type: 'blocked' });
 

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -50,7 +50,7 @@ router.post('/', async (req: express.Request, res: express.Response, next: expre
 router.put('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   try {
     const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
-    const modifiedTimeslot = createTimeSlotValidator(airfield.eventGranularityMinutes)
+    const modifiedTimeslot = createTimeSlotValidator(airfield.eventGranularityMinutes, true)
       .parse(req.body);
     // TODO: check if timeslot overlaps with existing timeslots
 

--- a/backend/src/services/timeslotService.ts
+++ b/backend/src/services/timeslotService.ts
@@ -133,13 +133,21 @@ const updateById = async (
     throw new Error('No timeslot with id exists');
   }
 
+  const slotHasMoved = oldTimeslot.start.getTime() !== timeslot.start.getTime();
   // if the timeslot has started, its start time can't be edited
   // and if timeslot has ended it's no longer editable at all
   if (
-    (oldTimeslot.start.getTime() !== timeslot.start.getTime()
+    (slotHasMoved
       && isTimeInPast(oldTimeslot.start))
     || isTimeInPast(oldTimeslot.end)) {
     throw new Error('Timeslot in past cannot be modified');
+  }
+
+  // prevent from being able to move start to past
+  if (
+    slotHasMoved && isTimeInPast(timeslot.start)
+  ) {
+    throw new Error('Timeslot cannot be moved to the past');
   }
 
   if (timeslot.type === 'available') {
@@ -153,6 +161,7 @@ const updateById = async (
     await oldTimeslot.removeReservations(oldReservations);
     await oldTimeslot.addReservations(newReservations);
   }
+
   await Timeslot.upsert({ ...timeslot, id });
 };
 

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -1,4 +1,6 @@
-import { EventRemoveArg, EventSourceFunc, AllowFunc } from '@fullcalendar/core';
+import {
+  EventRemoveArg, EventSourceFunc, AllowFunc, EventInput,
+} from '@fullcalendar/core';
 import { EventImpl } from '@fullcalendar/core/internal';
 import FullCalendar from '@fullcalendar/react';
 import React, { useState, useRef } from 'react';
@@ -32,11 +34,11 @@ function TimeSlotCalendar() {
   ) => {
     try {
       const timeslots = await getTimeSlots(start, end);
-      const timeslotsMapped = timeslots.map((timeslot) => {
-        const timeslotEvent = {
+      const timeslotsMapped = timeslots.map((timeslot): EventInput => {
+        const timeslotEvent: EventInput = {
           ...timeslot,
           id: timeslot.id.toString(),
-          editable: !isTimeInPast(timeslot.start),
+          editable: !isTimeInPast(timeslot.end),
           color: timeslot.type === 'available' ? '#84cc1680' : '#eec200',
           title: timeslot.type === 'available' ? 'Vapaa' : timeslot.info || 'Suljettu',
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17386,7 +17386,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@types/react": "^18.0.27",
-        "@types/react-datepicker": "*",
+        "@types/react-datepicker": "^4.10.0",
         "@types/react-dom": "^18.0.10",
         "@types/uuid": "^9.0.1",
         "autoprefixer": "^10.4.13",

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -16,7 +16,10 @@ const isTimeAtMostInFuture = (time: Date, maxDaysInFuture: number): boolean => {
   return time <= max;
 };
 
-const createTimeSlotValidator = (slotGranularityMinutes: number) => {
+const createTimeSlotValidator = (
+  slotGranularityMinutes: number,
+  ignoreStartInPast: boolean = false,
+) => {
   // Time must be a multiple of ${slotGranularityMinutes} minutes
   const minuteMultipleMessage = `Ajan tulee olla jokin ${slotGranularityMinutes} minuutin moninkerta`;
   const pastErrorMessage = 'Timeslot cannot be in past';
@@ -26,7 +29,7 @@ const createTimeSlotValidator = (slotGranularityMinutes: number) => {
     start: z.coerce
       .date()
       .refine(isMultipleOfMinutes(slotGranularityMinutes), { message: minuteMultipleMessage })
-      .refine((value) => !isTimeInPast(value), { message: pastErrorMessage }),
+      .refine((value) => ignoreStartInPast || !isTimeInPast(value), { message: pastErrorMessage }),
     end: z.coerce
       .date()
       .refine(isMultipleOfMinutes(slotGranularityMinutes), { message: minuteMultipleMessage })


### PR DESCRIPTION
Related to Issue #277 

## What changes has been added?
Timeslot editing is only blocked if the timeslot end time has passed or if the past start time is being moved.

### Backend
Validation for issue.
### Frontend
Handling of issue. The API call silently fails, but there's a check in the Calendar component for if the start time was moved which reverts the move.