### PR TITLE
#261 add airfield in route functionality and convert airfield to be accessed by icao code

### DIFF
--- a/backend/__tests__/reservationApi.test.ts
+++ b/backend/__tests__/reservationApi.test.ts
@@ -71,7 +71,7 @@ afterAll(async () => {
 
 describe('Calls to api', () => {
   test('can add a reservation with info', async () => {
-    const newReservation: any = await api.post('/api/reservations/')
+    const newReservation: any = await api.post('/api/EFHK/reservations/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: '11104040',
@@ -90,7 +90,7 @@ describe('Calls to api', () => {
   });
 
   test('can add a reservation without info', async () => {
-    const newReservation: any = await api.post('/api/reservations/')
+    const newReservation: any = await api.post('/api/EFHK/reservations/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-QAA', phone: '11104040',
@@ -109,7 +109,7 @@ describe('Calls to api', () => {
   });
 
   test('cannot create a reservation with empty phone number', async () => {
-    const result: any = await api.post('/api/reservations/')
+    const result: any = await api.post('/api/EFHK/reservations/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: ' ',
@@ -120,7 +120,7 @@ describe('Calls to api', () => {
   });
 
   test('cannot create a reservation with empty aircraft ID', async () => {
-    const result: any = await api.post('/api/reservations/')
+    const result: any = await api.post('/api/EFHK/reservations/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: ' ', info: 'Training flight', phone: '11104040',
@@ -136,7 +136,7 @@ describe('Calls to api', () => {
       end: new Date('2023-02-12T16:00:00.000Z'),
       type: 'blocked',
     });
-    const result: any = await api.post('/api/reservations/')
+    const result: any = await api.post('/api/EFHK/reservations/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-12T12:00:00.000Z'), end: new Date('2023-02-12T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: '11104040',
@@ -148,7 +148,7 @@ describe('Calls to api', () => {
   test('can delete a reservation', async () => {
     const createdReservation: Reservation | null = await Reservation.findOne();
     const id = createdReservation?.dataValues.id;
-    await api.delete(`/api/reservations/${id}`);
+    await api.delete(`/api/EFHK/reservations/${id}`);
 
     const deletedReservation: Reservation | null = await Reservation.findByPk(id);
     expect(deletedReservation).toBe(null);
@@ -158,7 +158,7 @@ describe('Calls to api', () => {
   });
 
   test('can\'t delete a reservation when it doesn\'t exists', async () => {
-    await api.delete('/api/reservations/-1');
+    await api.delete('/api/EFHK/reservations/-1');
     expect(await Reservation.count()).toEqual(reservations.length);
   });
 
@@ -170,7 +170,7 @@ describe('Calls to api', () => {
       phone: '11104040',
     });
 
-    await api.delete(`/api/reservations/${newReservation.id}`);
+    await api.delete(`/api/EFHK/reservations/${newReservation.id}`);
 
     expect(await Reservation.count()).toEqual(reservations.length + 1);
   });
@@ -180,7 +180,7 @@ describe('Calls to api', () => {
     const id = createdReservation?.dataValues.id;
     const aircraftId = createdReservation?.dataValues.aircraftId;
     const phone = createdReservation?.dataValues.phone;
-    await api.put(`/api/reservations/${id}`)
+    await api.put(`/api/EFHK/reservations/${id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-14T02:00:00.000Z', end: '2023-02-14T16:00:00.000Z', aircraftId, phone,
@@ -199,7 +199,7 @@ describe('Calls to api', () => {
     const createdReservation: Reservation | null = await Reservation.findOne();
     const id = createdReservation?.dataValues.id;
 
-    const updatedReservation: any = await api.put(`/api/reservations/${id}`)
+    const updatedReservation: any = await api.put(`/api/EFHK/reservations/${id}`)
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: ' ',
@@ -220,7 +220,7 @@ describe('Calls to api', () => {
       end: new Date('2023-02-12T16:00:00.000Z'),
       type: 'blocked',
     });
-    const result: any = await api.put(`/api/reservations/${id}`)
+    const result: any = await api.put(`/api/EFHK/reservations/${id}`)
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-12T12:00:00.000Z'), end: new Date('2023-02-12T14:00:00.000Z'), aircraftId: 'OH-QAA', info: 'Training flight', phone: '11104040',
@@ -233,7 +233,7 @@ describe('Calls to api', () => {
     const createdReservation: Reservation | null = await Reservation.findOne();
     const id = createdReservation?.dataValues.id;
 
-    const updatedReservation: any = await api.put(`/api/reservations/${id}`)
+    const updatedReservation: any = await api.put(`/api/EFHK/reservations/${id}`)
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: ' ', info: 'Training flight', phone: '11104040',
@@ -252,14 +252,17 @@ describe('Calls to api', () => {
 
     from.setHours(from.getHours() + 1);
     const response = await api
-      .get(`/api/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
+      .get(`/api/EFHK/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
 
     expect(response.body.length).toEqual(2);
-    expect(response.body).toMatchObject([{
-      aircraftId: 'DK-ASD', id: 41, info: null, phone: '0401111111', start: '2023-02-14T14:00:00.000Z', timeslotId: null, updatedAt: '2023-02-13T08:00:02.680Z', userId: null,
-    }, {
-      aircraftId: 'RF-SDR', id: 42, info: 'First time landing!', phone: '0401111111', start: '2023-02-14T16:00:00.000Z', timeslotId: null, updatedAt: '2023-02-13T08:00:02.680Z', userId: null,
-    }]);
+    expect(response.body).toMatchObject([reservations[1], reservations[2]].map(
+    // API response has dates as strings not date objects
+      ({ start, end, ...rest }) => ({
+        start: start.toISOString(),
+        end: end.toISOString(),
+        ...rest,
+      }),
+    ));
   });
 
   test('return an empty list if no reservation in range', async () => {
@@ -270,7 +273,7 @@ describe('Calls to api', () => {
     until.setDate(until.getDate() + 2);
 
     const response = await api
-      .get(`/api/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
+      .get(`/api/EFHK/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
     expect(response.body).toEqual([]);
   });
 
@@ -278,14 +281,14 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-13T06:00:00.000Z');
     const end = new Date('2023-02-13T08:00:00.000Z');
 
-    const newReservation: any = await api.post('/api/reservations/')
+    const newReservation: any = await api.post('/api/EFHK/reservations/')
       .set('Content-type', 'application/json')
       .send({
         start, end, aircraftId: 'OH-QAA', phone: '11104040',
       });
 
     const response = await api
-      .get(`/api/reservations?from=${start.toISOString()}&until=${end.toISOString()}`);
+      .get(`/api/EFHK/reservations?from=${start.toISOString()}&until=${end.toISOString()}`);
 
     expect(newReservation.status).toEqual(400);
     expect(response.body).toHaveLength(0);
@@ -298,7 +301,7 @@ describe('Calls to api', () => {
       aircraftId: 'OH-QAA',
       phone: '11104040',
     });
-    const response = await api.put(`/api/reservations/${newReservation.id}`)
+    const response = await api.put(`/api/EFHK/reservations/${newReservation.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-15T02:00:00.000Z',
@@ -319,7 +322,7 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-24T06:00:00.000Z');
     const end = new Date('2023-02-24T08:00:00.000Z');
 
-    const newReservation: any = await api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const newReservation: any = await api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     });
 
@@ -327,7 +330,7 @@ describe('Calls to api', () => {
     expect(newReservation.body.error.message).toContain('Voit tehdä varauksen korkeintaan');
 
     const response = await api
-      .get(`/api/reservations?from=${start.toISOString()}&until=${end.toISOString()}`);
+      .get(`/api/EFHK/reservations?from=${start.toISOString()}&until=${end.toISOString()}`);
 
     expect(response.body).toHaveLength(0);
   });
@@ -336,7 +339,7 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-24T08:00:00.000Z');
     const end = new Date('2023-02-24T06:00:00.000Z');
 
-    const newReservation: any = await api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const newReservation: any = await api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     });
 
@@ -344,13 +347,13 @@ describe('Calls to api', () => {
     expect(newReservation.body.error.message).toContain('Varauksen alkuaika ei voi olla myöhempi kuin loppuaika');
 
     const response = await api
-      .get(`/api/reservations?from=${start.toISOString()}&until=${end.toISOString()}`);
+      .get(`/api/EFHK/reservations?from=${start.toISOString()}&until=${end.toISOString()}`);
 
     expect(response.body).toHaveLength(0);
   });
 
   test('Reservation has to be within a timeslot upon creation', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-16T08:00:00.000Z'), end: new Date('2023-02-16T18:00:00.000Z'), type: 'available', info: null,
@@ -359,7 +362,7 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-16T07:00:00.000Z');
     const end = new Date('2023-02-16T09:00:00.000Z');
 
-    const newReservation: any = await api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const newReservation: any = await api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     });
 
@@ -371,23 +374,25 @@ describe('Calls to api', () => {
   });
 
   test('Reservation has to be within a timeslot when modified', async () => {
-    await api.post('/api/timeslots/')
+    const tsRes = await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-16T08:00:00.000Z'), end: new Date('2023-02-16T18:00:00.000Z'), type: 'available', info: null,
       });
 
+    expect(tsRes.body.error).not.toBeDefined();
+
     const start = new Date('2023-02-16T08:00:00.000Z');
     const newStart = new Date('2023-02-16T07:00:00.000Z');
     const end = new Date('2023-02-16T09:00:00.000Z');
 
-    const newReservation: any = await api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const newReservation: any = await api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     });
 
     expect(newReservation.body.error).not.toBeDefined();
 
-    const modifiedReservation: any = await api.put(`/api/reservations/${newReservation.id}`).set('Content-type', 'application/json').send({
+    const modifiedReservation: any = await api.put(`/api/EFHK/reservations/${newReservation.id}`).set('Content-type', 'application/json').send({
       ...newReservation.body, start: newStart, info: undefined,
       // TODO: fix weirdness with interacting with API where null isnt undefined
     });
@@ -402,7 +407,7 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-14T12:00:00.000Z');
     const end = new Date('2023-02-14T14:00:00.000Z');
 
-    const res = await Promise.all([...Array(3)].map(async () => api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const res = await Promise.all([...Array(3)].map(async () => api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     })));
 
@@ -416,11 +421,11 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-14T12:00:00.000Z');
     const end = new Date('2023-02-14T14:00:00.000Z');
 
-    await Promise.all([...Array(3)].map(async () => api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    await Promise.all([...Array(3)].map(async () => api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     })));
 
-    const res = await api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const res = await api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start, end, aircraftId: 'OH-ASD', phone: '+358494678748',
     });
 
@@ -443,9 +448,9 @@ describe('Calls to api', () => {
       {
         start: new Date('2023-02-14T13:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-DFG', phone: '+358494678748',
       },
-    ].map(async (flight) => api.post('/api/reservations/').set('Content-type', 'application/json').send(flight)));
+    ].map(async (flight) => api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send(flight)));
 
-    const res = await api.post('/api/reservations/').set('Content-type', 'application/json').send({
+    const res = await api.post('/api/EFHK/reservations/').set('Content-type', 'application/json').send({
       start: new Date('2023-02-14T12:00:00.000Z'), end: new Date('2023-02-14T14:00:00.000Z'), aircraftId: 'OH-FGH', phone: '+358494678748',
     });
 

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -52,7 +52,7 @@ afterAll(async () => {
 });
 describe('Calls to api', () => {
   test('can create an available timeslot', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-18T12:00:00.000Z'), end: new Date('2023-02-18T14:00:00.000Z'), type: 'available', info: null,
@@ -71,7 +71,7 @@ describe('Calls to api', () => {
   });
 
   test('can create a blocked timeslot', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-18T12:00:00.000Z'), end: new Date('2023-02-18T14:00:00.000Z'), type: 'blocked', info: 'Under maintenance',
@@ -91,7 +91,7 @@ describe('Calls to api', () => {
   });
 
   test('dont create a timeslot if all fields not provided', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({ start: '2023-02-18T12:00:00.000Z', type: 'available', info: null });
 
@@ -105,7 +105,7 @@ describe('Calls to api', () => {
   });
 
   test('dont create a timeslot if type is not available or blocked', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-18T12:00:00.000Z', end: new Date('2023-02-18T14:00:00.000Z'), type: 'error', info: null,
@@ -121,7 +121,7 @@ describe('Calls to api', () => {
   });
 
   test('dont create a timeslot if granularity is wrong', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-18T12:00:00.000Z'), end: new Date('2023-02-18T12:15:00.000Z'), type: 'available', info: null,
@@ -137,7 +137,7 @@ describe('Calls to api', () => {
   });
 
   test('dont create a timeslot if provided times are empty', async () => {
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: '', end: '', type: 'available', info: null,
@@ -151,7 +151,7 @@ describe('Calls to api', () => {
   test('can edit an available timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z'), type: 'available' });
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-17T12:00:00.000Z', end: '2023-02-17T14:00:00.000Z', type: 'available', info: null,
@@ -169,7 +169,7 @@ describe('Calls to api', () => {
   test('can edit a blocked timeslot', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z'), type: 'blocked' });
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-17T12:00:00.000Z', end: '2023-02-17T14:00:00.000Z', type: 'blocked', info: null,
@@ -194,7 +194,7 @@ describe('Calls to api', () => {
     });
     createdSlot.addReservations([newReservation]);
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-16T12:00:00.000Z', end: '2023-02-16T14:00:00.000Z', type: 'available', info: null,
@@ -212,7 +212,7 @@ describe('Calls to api', () => {
   test('dont edit a timeslot if all fields not provided', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z'), type: 'available' });
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({ start: '2023-02-17T12:00:00.000Z' });
 
@@ -228,7 +228,7 @@ describe('Calls to api', () => {
   test('dont edit a timeslot if granularity is wrong', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z'), type: 'available' });
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-17T12:00:00.000Z'), end: new Date('2023-02-17T13:15:00.000Z'), type: 'available', info: null,
@@ -246,7 +246,7 @@ describe('Calls to api', () => {
   test('dont edit a timeslot if type is not available or blocked', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T13:00:00.000Z'), type: 'available' });
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-17T12:00:00.000Z', end: new Date('2023-02-17T13:15:00.000Z'), type: 'error', info: null,
@@ -271,7 +271,7 @@ describe('Calls to api', () => {
     });
     createdSlot.addReservations([newReservation]);
 
-    await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({ start: '2023-02-16T12:00:00.000Z', end: '2023-02-16T13:00:00.000Z', type: 'available' });
 
@@ -287,7 +287,7 @@ describe('Calls to api', () => {
   test('dont edit a timeslot if it is in past', async () => {
     const createdSlot: Timeslot = await Timeslot.create({ start: new Date('2023-02-12T12:00:00.000Z'), end: new Date('2023-02-12T14:00:00.000Z'), type: 'available' });
 
-    const response = await api.put(`/api/timeslots/${createdSlot.dataValues.id}`)
+    const response = await api.put(`/api/EFHK/timeslots/${createdSlot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: '2023-02-16T12:00:00.000Z', end: '2023-02-16T13:00:00.000Z', type: 'available', info: null,
@@ -303,7 +303,7 @@ describe('Calls to api', () => {
 
   test('can delete a timeslot', async () => {
     const createdSlot: Timeslot | null = await Timeslot.findOne({});
-    await api.delete(`/api/timeslots/${createdSlot?.dataValues.id}`);
+    await api.delete(`/api/EFHK/timeslots/${createdSlot?.dataValues.id}`);
 
     const deletedSlot: Timeslot | null = await Timeslot.findByPk(createdSlot?.dataValues.id);
     const numberOfTimeslots: Number = await Timeslot.count();
@@ -313,7 +313,7 @@ describe('Calls to api', () => {
   });
 
   test('dont delete a timeslot if it doesnt exist', async () => {
-    await api.delete('/api/timeslots/-1');
+    await api.delete('/api/EFHK/timeslots/-1');
 
     const numberOfTimeslots: Number = await Timeslot.count();
 
@@ -327,7 +327,7 @@ describe('Calls to api', () => {
       type: 'available',
     });
 
-    await api.delete(`/api/timeslots/${newTimeslot.id}`);
+    await api.delete(`/api/EFHK/timeslots/${newTimeslot.id}`);
 
     expect(await Timeslot.count()).toEqual(timeslotData.length + 1);
   });
@@ -342,7 +342,7 @@ describe('Calls to api', () => {
     });
     await createdSlot?.addReservations([newReservation]);
 
-    await api.delete(`/api/timeslots/${createdSlot?.id}`);
+    await api.delete(`/api/EFHK/timeslots/${createdSlot?.id}`);
 
     const deletedSlot = await Timeslot.findByPk(createdSlot?.id);
     const numberOfTimeslots: Number = await Timeslot.count();
@@ -353,7 +353,7 @@ describe('Calls to api', () => {
   test('can get timeslots in a range', async () => {
     const from = new Date(timeslotDataBegin);
     const until = new Date(timeslotDataEnd);
-    const response = await api.get(`/api/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
+    const response = await api.get(`/api/EFHK/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
     const timeslots = response.body;
     const startTimes = timeslots.map((o: { start: String; }) => o.start);
 
@@ -366,7 +366,7 @@ describe('Calls to api', () => {
     const until = new Date(timeslotDataEnd);
     from.setDate(until.getDate() + 1);
     until.setDate(until.getDate() + 2);
-    const response = await api.get(`/api/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
+    const response = await api.get(`/api/EFHK/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
 
     expect(response.body).toEqual([]);
   });
@@ -375,7 +375,7 @@ describe('Calls to api', () => {
     const start = new Date('2023-02-24T08:00:00.000Z');
     const end = new Date('2023-02-24T06:00:00.000Z');
 
-    const newTimeslot: any = await api.post('/api/timeslots/').set('Content-type', 'application/json').send({
+    const newTimeslot: any = await api.post('/api/EFHK/timeslots/').set('Content-type', 'application/json').send({
       start, end, type: 'available', info: null,
     });
 
@@ -383,7 +383,7 @@ describe('Calls to api', () => {
     expect(newTimeslot.body.error.message).toContain('start time cannot be later than the end time');
 
     const response = await api
-      .get(`/api/timeslots?from=${start.toISOString()}&until=${end.toISOString()}`);
+      .get(`/api/EFHK/timeslots?from=${start.toISOString()}&until=${end.toISOString()}`);
 
     expect(response.body).toHaveLength(0);
   });

--- a/backend/__tests__/timeslotApi.test.ts
+++ b/backend/__tests__/timeslotApi.test.ts
@@ -97,7 +97,7 @@ describe('Calls to api', () => {
       aircraftId: 'ESA-111',
       phone: '0501102323',
     });
-    await api.post('/api/timeslots/')
+    await api.post('/api/EFHK/timeslots/')
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-16T12:00:00.000Z'), end: new Date('2023-02-16T14:00:00.000Z'), type: 'blocked', info: 'Under maintenance',
@@ -120,7 +120,7 @@ describe('Calls to api', () => {
       aircraftId: 'ESA-111',
       phone: '0501102323',
     });
-    await api.put(`/api/timeslots/${timeslot.dataValues.id}`)
+    await api.put(`/api/EFHK/timeslots/${timeslot.dataValues.id}`)
       .set('Content-type', 'application/json')
       .send({
         start: new Date('2023-02-16T10:00:00.000Z'), end: new Date('2023-02-16T16:00:00.000Z'), type: 'blocked', info: 'Under maintenance',

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,18 +3,37 @@ import cors from 'cors';
 import timeslotRouter from './routes/timeslots';
 import reservationRouter from './routes/reservations';
 import airfieldRouter from './routes/airfields';
-import errorHandler from './util/middleware';
+import { errorHandler, airfieldExtractor } from './util/middleware';
+import { Airfield } from './models';
 
 const app = express();
 
+// Not sure if this is the right place for t  s.
+// But this extends the express request to allow for custom keys
+// like req.airfield
+declare global {
+  namespace Express {
+    interface Request {
+      airfield: Airfield | null
+    }
+  }
+}
+
 app.use(express.json());
 app.use(cors());
+
 app.get('/api', async (_req: any, res: express.Response) => {
   res.send('Hello World');
 });
-app.use('/api/timeslots', timeslotRouter);
-app.use('/api/reservations', reservationRouter);
+
+// mergeParams required because otherwise the params won't be there as they're defined up here
+const aeRouter = express.Router({ mergeParams: true }).use(airfieldExtractor);
+app.use('/api/:airfieldCode/', aeRouter);
+aeRouter.use('/reservations', reservationRouter);
+aeRouter.use('/timeslots', timeslotRouter);
+
 app.use('/api/airfields', airfieldRouter);
+
 app.use(errorHandler);
 
 export default app;

--- a/backend/src/models/airfield.ts
+++ b/backend/src/models/airfield.ts
@@ -3,7 +3,6 @@ import {
   DataTypes,
   InferAttributes,
   InferCreationAttributes,
-  CreationOptional,
 } from 'sequelize';
 
 import { sequelize } from '../util/db';
@@ -12,7 +11,7 @@ class Airfield extends Model<
 InferAttributes<Airfield>,
 InferCreationAttributes<Airfield>
 > {
-  declare id: CreationOptional<number>;
+  declare code: string;
 
   declare name: string;
 
@@ -23,10 +22,11 @@ InferCreationAttributes<Airfield>
 
 Airfield.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
+    code: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
       primaryKey: true,
-      autoIncrement: true,
     },
     name: {
       type: DataTypes.STRING,

--- a/backend/src/routes/airfields.ts
+++ b/backend/src/routes/airfields.ts
@@ -15,7 +15,7 @@ router.get('/', async (req: express.Request, res: express.Response, next: expres
   }
 });
 
-router.get('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+router.get('/:code', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   const { code } = req.params;
   try {
     const airfield = await airfieldService.getAirfield(code);
@@ -25,7 +25,7 @@ router.get('/:id', async (req: express.Request, res: express.Response, next: exp
   }
 });
 
-router.put('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+router.put('/:code', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   const { code } = req.params;
   try {
     const airfieldEntry: AirfieldEntry = airfieldValidator.parse(req.body);

--- a/backend/src/routes/airfields.ts
+++ b/backend/src/routes/airfields.ts
@@ -16,9 +16,9 @@ router.get('/', async (req: express.Request, res: express.Response, next: expres
 });
 
 router.get('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-  const id = Number(req.params.id);
+  const { code } = req.params;
   try {
-    const airfield = await airfieldService.getAirfield(id);
+    const airfield = await airfieldService.getAirfield(code);
     res.json(airfield);
   } catch (error: unknown) {
     next(error);
@@ -26,10 +26,10 @@ router.get('/:id', async (req: express.Request, res: express.Response, next: exp
 });
 
 router.put('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-  const id = Number(req.params.id);
+  const { code } = req.params;
   try {
     const airfieldEntry: AirfieldEntry = airfieldValidator.parse(req.body);
-    const airfield = await airfieldService.updateById(id, airfieldEntry);
+    const airfield = await airfieldService.updateByCode(code, airfieldEntry);
     res.json(airfield);
   } catch (error: unknown) {
     next(error);

--- a/backend/src/routes/reservations.ts
+++ b/backend/src/routes/reservations.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import countMostConcurrent from '@lentovaraukset/shared/src/overlap';
 import { createReservationValidator, getTimeRangeValidator } from '@lentovaraukset/shared/src/validation/validation';
 import reservationService from '../services/reservationService';
-import airfieldService from '../services/airfieldService';
+import { errorIfNoAirfield } from '../util/middleware';
 
 const allowReservation = async (
   startTime: Date,
@@ -43,7 +43,8 @@ router.delete('/:id', async (req: express.Request, res: express.Response, next: 
 
 router.post('/', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   try {
-    const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
+    errorIfNoAirfield(req);
+    const { airfield } = req;
     // TODO: get maxDaysInFuture from airfield
     const newReservation = createReservationValidator(airfield.eventGranularityMinutes, 7)
       .parse(req.body);
@@ -67,7 +68,9 @@ router.post('/', async (req: express.Request, res: express.Response, next: expre
 router.put('/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   try {
     const id = Number(req.params.id);
-    const airfield = await airfieldService.getAirfield(1); // TODO: get airfieldId from request
+    errorIfNoAirfield(req);
+    const { airfield } = req;
+
     const validReservationUpdate = createReservationValidator(airfield.eventGranularityMinutes, 7)
       .parse(req.body);
 

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -80,7 +80,9 @@ router.put('/:id', async (req: express.Request, res: express.Response, next: exp
 
 router.put('/group/:group', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   try {
-    const airfield = await airfieldService.getAirfield('EGLL'); // TODO: get airfieldId from request
+    errorIfNoAirfield(req);
+
+    const { airfield } = req; // TODO: get airfieldId from request
     const { group } = req.params;
     const updatedTimes = createGroupUpdateValidator(airfield.eventGranularityMinutes)
       .parse(req.body);

--- a/backend/src/routes/timeslots.ts
+++ b/backend/src/routes/timeslots.ts
@@ -81,9 +81,8 @@ router.put('/:id', async (req: express.Request, res: express.Response, next: exp
 router.put('/group/:group', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   try {
     errorIfNoAirfield(req);
+    const { airfield, params: { group } } = req;
 
-    const { airfield } = req; // TODO: get airfieldId from request
-    const { group } = req.params;
     const updatedTimes = createGroupUpdateValidator(airfield.eventGranularityMinutes)
       .parse(req.body);
     const updatedTimeslots = await timeslotService.updateByGroup(group, updatedTimes);

--- a/backend/src/services/airfieldService.ts
+++ b/backend/src/services/airfieldService.ts
@@ -1,10 +1,10 @@
 import { AirfieldEntry } from '@lentovaraukset/shared/src';
 import { Airfield } from '../models';
 
-const getAirfield = async (id: number): Promise<AirfieldEntry> => {
+const getAirfield = async (code: string): Promise<AirfieldEntry> => {
   const airfield = await Airfield.findOne({
     where: {
-      id,
+      code,
     },
   });
 
@@ -20,12 +20,12 @@ const getAirfields = async (): Promise<AirfieldEntry[]> => {
   return airfields.map((airfield) => airfield.dataValues);
 };
 
-const updateById = async (
-  id: number,
+const updateByCode = async (
+  code: string,
   airfield: AirfieldEntry,
 ): Promise<AirfieldEntry> => {
   const [updatedAirfield] = await Airfield.upsert(
-    { ...airfield, id },
+    { ...airfield, code },
   );
   return updatedAirfield.dataValues;
 };
@@ -33,8 +33,8 @@ const updateById = async (
 const createTestAirfield = async () => {
   // TODO: Remove this when we have a proper admin interface for creating airfields
   await Airfield.upsert({
-    id: 1,
-    name: 'Test Airfield',
+    code: 'EFHK',
+    name: 'Helsinki-Vantaan lentoasema',
     maxConcurrentFlights: 3,
     eventGranularityMinutes: 20,
   });
@@ -43,6 +43,6 @@ const createTestAirfield = async () => {
 export default {
   getAirfield,
   getAirfields,
-  updateById,
+  updateByCode,
   createTestAirfield,
 };

--- a/backend/src/services/airfieldService.ts
+++ b/backend/src/services/airfieldService.ts
@@ -2,11 +2,7 @@ import { AirfieldEntry } from '@lentovaraukset/shared/src';
 import { Airfield } from '../models';
 
 const getAirfield = async (code: string): Promise<AirfieldEntry> => {
-  const airfield = await Airfield.findOne({
-    where: {
-      code,
-    },
-  });
+  const airfield = await Airfield.findByPk(code);
 
   if (!airfield) {
     throw new Error('Airfield not found');

--- a/backend/src/util/middleware.ts
+++ b/backend/src/util/middleware.ts
@@ -1,7 +1,8 @@
 import { ServiceErrorCode } from '@lentovaraukset/shared/src';
 import { NextFunction, Request, Response } from 'express';
 import * as z from 'zod';
-import { isSpecificServiceError } from './errors';
+import { Airfield } from '../models';
+import ServiceError, { isSpecificServiceError } from './errors';
 
 const handleZodError = (zodError: z.ZodError): {
   validationIssues: z.typeToFlattenedError<any, { message: string, code: z.ZodIssueCode }>,
@@ -18,11 +19,13 @@ const handleZodError = (zodError: z.ZodError): {
   return { validationIssues, statusCode, message: zodError.message };
 };
 
-const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
+export const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
   if (err instanceof z.ZodError) {
     const { message, statusCode, validationIssues } = handleZodError(err);
     res.status(statusCode).json({ error: { message, validationIssues } });
   } else if (isSpecificServiceError(err, ServiceErrorCode.ReservationExceedsTimeslot)) {
+    res.status(400).json({ error: { code: err.errorCode, message: err.message } });
+  } else if (isSpecificServiceError(err, ServiceErrorCode.InvalidAirfield)) {
     res.status(400).json({ error: { code: err.errorCode, message: err.message } });
   } else {
     const statusCode = err.statusCode || 500;
@@ -32,4 +35,19 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
   next();
 };
 
-export default errorHandler;
+export const airfieldExtractor = async (req: Request, res: Response, next: NextFunction) => {
+  const { airfieldCode } = req.params;
+  // this could save the promise instead if blocking is bad
+  try {
+    req.airfield = await Airfield.findByPk(airfieldCode);
+  } finally {
+    next();
+  }
+};
+
+//                                               TS why can I not just type req.airfield is Airfield
+export function errorIfNoAirfield(req: Request): asserts req is Omit<Request, 'airfield'> & { airfield: Airfield } {
+  if (req.airfield === null) {
+    throw new ServiceError(ServiceErrorCode.InvalidAirfield, 'Supplied airfield code could not be found');
+  }
+}

--- a/frontend/src/components/forms/AirfieldForm.tsx
+++ b/frontend/src/components/forms/AirfieldForm.tsx
@@ -27,7 +27,7 @@ function AirfieldForm(
 
   const onSubmit: SubmitHandler<Inputs> = (data: Inputs) => {
     airfieldMutator.mutate({
-      ...data, id: airfield.id,
+      ...data, code: airfield.code,
     });
   };
 
@@ -36,7 +36,7 @@ function AirfieldForm(
       <div className="p-8">
         <form className="flex flex-col w-full space-y-4" onSubmit={handleSubmit(onSubmit)}>
           <p>
-            {`Id: ${airfield.id}`}
+            {`Kentän tunnus: ${airfield.code}`}
           </p>
           <InputField
             labelText="Nimi:"

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -45,7 +45,7 @@ function RecurringTimeslotForm({
   onSubmit,
   id,
 }: RecurringTimeslotProps) {
-  const { data: airfield } = useAirfield(1);
+  const { data: airfield } = useAirfield('EFHK');
   const timeslotGranularity = airfield?.eventGranularityMinutes || 20;
 
   const start = timeslot?.startStr.replace(/.{3}\+.*/, '') || HTMLDateTimeConvert(draggedTimes?.start) || '';

--- a/frontend/src/components/forms/ReservationInfoForm.tsx
+++ b/frontend/src/components/forms/ReservationInfoForm.tsx
@@ -31,7 +31,7 @@ function ReservationInfoForm({
   onSubmit,
   id,
 }: ReservationInfoProps) {
-  const { data: airfield } = useAirfield(1);
+  const { data: airfield } = useAirfield('EFHK');
   const reservationGranularity = airfield?.eventGranularityMinutes || 20;
 
   const start = reservation?.startStr.replace(/.{3}\+.*/, '') || HTMLDateTimeConvert(draggedTimes?.start) || '';

--- a/frontend/src/pages/Management.tsx
+++ b/frontend/src/pages/Management.tsx
@@ -4,7 +4,7 @@ import AirfieldForm from '../components/forms/AirfieldForm';
 import { useAirfield } from '../queries/airfields';
 
 function Management() {
-  const { isLoading, data: airfield } = useAirfield(1); // TODO: get id from airfield selection
+  const { isLoading, data: airfield } = useAirfield('EFHK'); // TODO: get id from airfield selection
   return (
     isLoading
       ? <p>Ladataan...</p>

--- a/frontend/src/pages/ReservationCalendar.tsx
+++ b/frontend/src/pages/ReservationCalendar.tsx
@@ -23,7 +23,7 @@ function ReservationCalendar() {
   const calendarRef: React.RefObject<FullCalendar> = React.createRef();
 
   const { showPopup, clearPopup } = usePopupContext();
-  const { data: airfield } = useAirfield(1); // TODO: get id from airfield selection
+  const { data: airfield } = useAirfield('EFHK'); // TODO: get id from airfield selection
   const { addNewAlert } = useContext(AlertContext);
   const reservationsSourceFn: EventSourceFunc = async (
     { start, end },

--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -18,7 +18,7 @@ import { usePopupContext } from '../contexts/PopupContext';
 
 function TimeSlotCalendar() {
   const calendarRef = useRef<FullCalendar>(null);
-  const { data: airfield } = useAirfield(1); // TODO: get id from airfield selection
+  const { data: airfield } = useAirfield('EFHK'); // TODO: get id from airfield selection
   const { showPopup, clearPopup } = usePopupContext();
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [blocked, setBlocked] = useState(false);

--- a/frontend/src/queries/airfields.ts
+++ b/frontend/src/queries/airfields.ts
@@ -5,21 +5,21 @@ import {
 import QueryKeys from './queryKeys';
 import { errorIfNotOk } from './util';
 
-const getAirfields = async (airfieldId: number): Promise<AirfieldEntry> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/airfields/${airfieldId}`);
+const getAirfields = async (airfieldCode: string): Promise<AirfieldEntry> => {
+  const res = await fetch(`${process.env.BASE_PATH}/api/airfields/${airfieldCode}`);
   errorIfNotOk(res);
   return res.json();
 };
 
-const useAirfield = (airfieldId: number) => useQuery(
-  [QueryKeys.Airfield, airfieldId],
-  () => getAirfields(airfieldId),
+const useAirfield = (airfieldCode: string) => useQuery(
+  [QueryKeys.Airfield, airfieldCode],
+  () => getAirfields(airfieldCode),
 );
 
 const modifyAirfield = async (
   modifiedAirfield: AirfieldEntry,
 ): Promise<AirfieldEntry> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/airfields/${modifiedAirfield.id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/airfields/${modifiedAirfield.code}`, {
     method: 'PUT',
     body: JSON.stringify(modifiedAirfield),
     headers: {

--- a/frontend/src/queries/reservations.ts
+++ b/frontend/src/queries/reservations.ts
@@ -1,14 +1,16 @@
 import { ReservationEntry } from '@lentovaraukset/shared/src';
 import { errorIfNotOk } from './util';
 
+const airfieldCode = 'EFHK';
+
 const getReservations = async (from: Date, until: Date): Promise<ReservationEntry[]> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/reservations?from=${from.toISOString()}&until=${until.toISOString()}`);
   errorIfNotOk(res);
   return res.json();
 };
 
 const addReservation = async (newReservation: any): Promise<ReservationEntry> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/reservations/`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/reservations/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -22,7 +24,7 @@ const addReservation = async (newReservation: any): Promise<ReservationEntry> =>
 };
 
 const deleteReservation = async (id: Number): Promise<string> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/reservations/${id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/reservations/${id}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -35,7 +37,7 @@ const deleteReservation = async (id: Number): Promise<string> => {
 const modifyReservation = async (
   modifiedReservation: ReservationEntry,
 ): Promise<ReservationEntry> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/reservations/${modifiedReservation.id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/reservations/${modifiedReservation.id}`, {
     method: 'PUT',
     body: JSON.stringify(modifiedReservation),
     headers: {

--- a/frontend/src/queries/timeSlots.ts
+++ b/frontend/src/queries/timeSlots.ts
@@ -35,7 +35,7 @@ const modifyTimeSlot = async (
     days: period?.days,
   };
 
-  const res = await fetch(`${process.env.BASE_PATH}/${airfieldCode}/api/timeslots/${timeSlot.id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/timeslots/${timeSlot.id}`, {
     method: 'PUT',
     body: JSON.stringify(modifiedTimeSlot),
     headers: {
@@ -46,7 +46,7 @@ const modifyTimeSlot = async (
 };
 
 const deleteTimeslot = async (id: Number): Promise<string> => {
-  const res = await fetch(`${process.env.BASE_PATH}/${airfieldCode}/api/timeslots/${id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/timeslots/${id}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -61,7 +61,7 @@ const modifyGroup = async (group: string, updates: {
   startTimeOfDay: { hours: number, minutes: number },
   endTimeOfDay: { hours: number, minutes: number }
 }): Promise<void> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/group/${group}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/timeslots/group/${group}`, {
     method: 'PUT',
     body: JSON.stringify(updates),
     headers: {

--- a/frontend/src/queries/timeSlots.ts
+++ b/frontend/src/queries/timeSlots.ts
@@ -1,14 +1,16 @@
 import { TimeslotEntry, WeekInDays } from '@lentovaraukset/shared/src';
 import { errorIfNotOk } from './util';
 
+const airfieldCode = 'EFHK';
+
 const getTimeSlots = async (from: Date, until: Date): Promise<TimeslotEntry[]> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
   errorIfNotOk(res);
   return res.json();
 };
 
 const addTimeSlot = async (newTimeSlot: { start: Date, end: Date, type: 'available' | 'blocked', info: string | null }): Promise<void> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/`, {
+  const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/timeslots/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -33,7 +35,7 @@ const modifyTimeSlot = async (
     days: period?.days,
   };
 
-  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/${timeSlot.id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/${airfieldCode}/api/timeslots/${timeSlot.id}`, {
     method: 'PUT',
     body: JSON.stringify(modifiedTimeSlot),
     headers: {
@@ -44,7 +46,7 @@ const modifyTimeSlot = async (
 };
 
 const deleteTimeslot = async (id: Number): Promise<string> => {
-  const res = await fetch(`${process.env.BASE_PATH}/api/timeslots/${id}`, {
+  const res = await fetch(`${process.env.BASE_PATH}/${airfieldCode}/api/timeslots/${id}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -21,7 +21,7 @@ export interface TimeslotEntry {
 }
 
 export interface AirfieldEntry {
-  id?: number;
+  code?: string;
   name: string;
   maxConcurrentFlights: number;
   eventGranularityMinutes: number;
@@ -29,6 +29,7 @@ export interface AirfieldEntry {
 
 export enum ServiceErrorCode {
   ReservationExceedsTimeslot = 'ReservationExceedsTimeslot',
+  InvalidAirfield = 'InvalidAirfield',
 }
 
 export interface WeekInDays {


### PR DESCRIPTION
Related to Issue #261 

### Backend
API paths to reservations and timeslots are now of the shape `/api/:airfieldid/reservations`. The routes can access the airfield like this:  
```ts
import { errorIfNoAirfield } from '../util/middleware';
// ...and in route:
errorIfNoAirfield(req); // asserts that airfield is there because it can be null
const { airfield } = req;
```

### Frontend
```ts
const airfieldCode = 'EFHK';
const res = await fetch(`${process.env.BASE_PATH}/api/${airfieldCode}/timeslots?from=${from.toISOString()}&until=${until.toISOString()}`);
```
Airfield queries were also changed to use the airfield code instead of an arbitrary ID.
## Expected Behaviour
Yes
