### PR TITLE
Subheader-komponentti

### DIFF
--- a/frontend/src/components/Subheader.tsx
+++ b/frontend/src/components/Subheader.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface SubheaderProps {
+  children: string;
+  className?: string;
+}
+const subheaderBaseClass = 'font-publicSans font-medium text-base text-black align-left align-top leading-[137.5%]';
+
+function Subheader({ children, className }: SubheaderProps) {
+  return (
+    <h2 className={`${subheaderBaseClass} ${className}`}>
+      {children}
+    </h2>
+  );
+}
+
+export default Subheader;

--- a/frontend/src/components/Subheader.tsx
+++ b/frontend/src/components/Subheader.tsx
@@ -4,7 +4,7 @@ interface SubheaderProps {
   children: string;
   className?: string;
 }
-const subheaderBaseClass = 'font-publicSans font-medium text-base text-black align-left align-top leading-[137.5%]';
+const subheaderBaseClass = 'font-sans text-ft-text-1000 text-left text-top leading-[137.5%]';
 
 function Subheader({ children, className }: SubheaderProps) {
   return (


### PR DESCRIPTION
Related to Issue #

## What changes has been added?

### Backend

### Frontend

## Expected Behaviour

```
<Subheader>This is a subheader</Subheader>
```

![image](https://user-images.githubusercontent.com/77497637/228523139-ed10f5c2-cc4f-4486-8f4e-6496ba1c91c6.png)
