### PR TITLE
Validointi lentokentälle hyväksyy liian pitkän koodin

### DIFF
--- a/backend/__tests__/airfieldApi.test.ts
+++ b/backend/__tests__/airfieldApi.test.ts
@@ -79,4 +79,30 @@ describe('Calls to api', () => {
     expect(res.body.error.message).toContain('already exists');
     expect(numberOfAirfields).toEqual(airfields.length);
   });
+
+  test('dont create an airfield if code too short', async () => {
+    const res = await api.post('/api/airfields/')
+      .set('Content-type', 'application/json')
+      .send({
+        code: 'EFH', name: 'Malmi', maxConcurrentFlights: 2, eventGranularityMinutes: 20,
+      });
+
+    const numberOfAirfields: Number = await Airfield.count();
+
+    expect(res.body.error.message).toContain('must be ICAO airport code');
+    expect(numberOfAirfields).toEqual(airfields.length);
+  });
+
+  test('dont create an airfield if code too long', async () => {
+    const res = await api.post('/api/airfields/')
+      .set('Content-type', 'application/json')
+      .send({
+        code: 'EFHKK', name: 'Malmi', maxConcurrentFlights: 2, eventGranularityMinutes: 20,
+      });
+
+    const numberOfAirfields: Number = await Airfield.count();
+
+    expect(res.body.error.message).toContain('must be ICAO airport code');
+    expect(numberOfAirfields).toEqual(airfields.length);
+  });
 });

--- a/shared/src/validation/validation.ts
+++ b/shared/src/validation/validation.ts
@@ -116,7 +116,7 @@ const airfieldValidator = (validateId: boolean = true) => {
   const concurrentFlightsMessage = 'Concurrent flights must be minimum 1';
   const multipleErrorMessage = 'Time must be multiple of 10';
   const idErrorMessage = 'Id must be ICAO airport code';
-  const regex = /[A-Z]{4}$/;
+  const regex = /^[A-Z]{4}$/;
 
   const base = z.object({
     name: z.string().min(1, { message: nameEmptyErrorMessage }),


### PR DESCRIPTION
Related to Issue #305 

## What changes has been added?

### Backend
Regex is corrected so that it does not accept too long input anymore.

### Frontend

## Expected Behaviour
It is not possible to add airfield which has too long code (over 4 characters). 

