### PR TITLE
Disable autofocus on first form input

### DIFF
--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -54,7 +54,7 @@ function DatePicker({
   }, [errorsExist]);
 
   return (
-    <div className="flex flex-col items-start flex-wrap">
+    <div className="flex flex-col items-start flex-wrap w-full">
       { labelText ? (
         <label
           htmlFor={id}

--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -90,7 +90,7 @@ function InputField({
   return (
     <div className={type === 'checkbox'
       ? 'flex flex-row justify-start items-baseline gap-x-2'
-      : 'flex flex-col items-start flex-wrap gap-y-1'}
+      : 'flex flex-col items-start flex-wrap gap-y-1 w-full'}
     >
       {labelText ? (
         <label

--- a/frontend/src/components/forms/RecurringTimeslotForm.tsx
+++ b/frontend/src/components/forms/RecurringTimeslotForm.tsx
@@ -180,7 +180,8 @@ function RecurringTimeslotForm({
         clearAlert={() => setFormWarning(undefined)}
         removalDelaySecs={10}
       />
-      <div className="p-8">
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <div className="p-8 outline-none" tabIndex={0} aria-label="press tab to enter the time window form">
         <form id={id} className="flex flex-col" onSubmit={handleSubmit(submitHandler, onError)}>
           <div className="flex flex-col sm:flex-row space-x-0 sm:space-x-6 w-full">
             <DatePicker

--- a/frontend/src/components/forms/ReservationInfoForm.tsx
+++ b/frontend/src/components/forms/ReservationInfoForm.tsx
@@ -90,7 +90,8 @@ function ReservationInfoForm({
         clearAlert={() => setFormWarning(undefined)}
         removalDelaySecs={10}
       />
-      <div className="p-8">
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <div className="p-8 outline-none" tabIndex={0} aria-label="press tab to enter the reservation form">
         <form
           id={id}
           className="flex flex-col w-full"

--- a/frontend/src/components/forms/ReservationInfoForm.tsx
+++ b/frontend/src/components/forms/ReservationInfoForm.tsx
@@ -91,8 +91,12 @@ function ReservationInfoForm({
         removalDelaySecs={10}
       />
       <div className="p-8">
-        <form id={id} className="flex flex-col w-full" onSubmit={handleSubmit(submitHandler)}>
-          <div className="flex flex-col sm:flex-row space-x-0 sm:space-x-6 w-full">
+        <form
+          id={id}
+          className="flex flex-col w-full"
+          onSubmit={handleSubmit(submitHandler)}
+        >
+          <div className="flex flex-col sm:flex-row justify-between space-x-0 sm:space-x-6 w-full">
             <DatePicker
               control={control}
               labelText="Varaus alkaa (UTC):"
@@ -110,7 +114,7 @@ function ReservationInfoForm({
               errors={errors}
             />
           </div>
-          <div className="flex flex-col sm:flex-row space-x-0 sm:space-x-6 w-full">
+          <div className="flex flex-col sm:flex-row justify-between space-x-0 sm:space-x-6 w-full">
             <InputField
               labelText="Koneen rekisteritunnus:"
               type="text"


### PR DESCRIPTION
Related to Issue #340 

## What changes has been added?

Modal now autofocuses on the form element instead of the first form input preventing datepicker from opening automatically. Added a guiding aria-label on the from elements.

Fixed a layout problem with form fields.

## Expected Behaviour

Opening a modal and pressing tab once should now focus on the first form input.