### PR TITLE
fix: open modal when dragging or moving a reservation

### DIFF
--- a/frontend/src/pages/TimeSlotCalendar.tsx
+++ b/frontend/src/pages/TimeSlotCalendar.tsx
@@ -95,7 +95,11 @@ function TimeSlotCalendar() {
 
   const closeTimeslotModalFn = () => setShowInfoModal(false);
 
-  const clickTimeslot = async (event: EventImpl): Promise<void> => {
+  /**
+   * Opens timeslot modal, if event is not in past
+   * @param event Event that is clicked, dragged or moved
+   */
+  const clickOrDragTimeslot = async (event: EventImpl): Promise<void> => {
     if (event.end && isTimeInPast(event.end)) {
       return;
     }
@@ -274,8 +278,8 @@ function TimeSlotCalendar() {
             calendarRef={calendarRef}
             eventSources={eventsSourceRef.current}
             addEventFn={showModalAfterDrag}
-            modifyEventFn={modifyTimeslotFn}
-            clickEventFn={clickTimeslot}
+            modifyEventFn={clickOrDragTimeslot}
+            clickEventFn={clickOrDragTimeslot}
             removeEventFn={removeTimeSlot}
             granularity={airport && { minutes: airport.eventGranularityMinutes }}
             eventColors={{ backgroundColor: blocked ? '#eec200' : '#bef264', eventColor: blocked ? '#b47324' : '#84cc1680', textColor: '#000000' }}


### PR DESCRIPTION
Related to Issue #337 

## What changes has been added?
Timeslot modal is opened everytime timeslot is dragged or moved. If modified blocked timeslot would remove reservations, it is warned and popup is shown

### Backend

### Frontend

## Expected Behaviour
